### PR TITLE
[helm] support initialize client

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -14,6 +14,7 @@ RUN apk --update --no-cache add ca-certificates
 ADD http://storage.googleapis.com/kubernetes-helm/${HELM_FILE_NAME} /tmp
 RUN tar -zxvf /tmp/${HELM_FILE_NAME} -C /tmp \
   && mv /tmp/linux-amd64/helm /bin/helm \
-  && rm -rf /tmp/*
+  && rm -rf /tmp/* \
+  && /bin/helm init --client-only
 
 ENTRYPOINT ["/bin/helm"]


### PR DESCRIPTION
Problem: run is not work.

```
$ docker run chatwork/helm repo list
Error: Couldn't load repositories file (/root/.helm/repository/repositories.yaml).
You might need to run `helm init` (or `helm init --client-only` if tiller is already installed)
```


