### PR TITLE
fixes ci:diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,9 @@ jobs:
       docker_layer_caching: true
     steps:
       - checkout
-      - run: make build
-      - run: make test
+      - run: make ci:diff
+      - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && make build"
+      - run: make ci:diff | xargs -I{} /bin/bash -c "cd ./{} && make test"
   push:
     machine: true
     steps:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ push:
 .PHONY: ci\:diff\:from
 ci\:diff\:from:
 	@branch=$$(git symbolic-ref --short HEAD); \
-		if [[ "$${branch}" == "master" ]]; then \
+		if [ "$${branch}" = "master" ]; then \
 			git --no-pager log --merges -n 2 --pretty=format:"%H" | tail -n 1; \
 		else \
 			echo "HEAD"; \
@@ -22,7 +22,7 @@ ci\:diff\:from:
 .PHONY: ci\:diff\:to
 ci\:diff\:to:
 	@branch=$$(git symbolic-ref --short HEAD); \
-		if [[ "$${branch}" == "master" ]]; then \
+		if [ "$${branch}" = "master" ]; then \
 			echo "HEAD"; \
 		else \
 			echo "master"; \


### PR DESCRIPTION
There was a problem that `CIRCLE_COMPARE_URL` saw only the difference from the last build.
So changed it as follows.

* `master` branch will see the difference to the previous merge.
* `PR` branch will see the difference with `master` branch.
* Builds and tests only perform differences