### PR TITLE
[aws] fixes empty environment variable for AWS

### DIFF
--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -5,8 +5,11 @@ ARG AWS_VERSION=1.16.39
 LABEL version="${AWS_VERSION}"
 LABEL maintainer="ozaki@chatwork.com"
 
+COPY entrypoint.sh /entrypoint.sh
+
 RUN apk --no-cache add py3-pip jq \
     && pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir awscli==${AWS_VERSION}
+    && pip3 install --no-cache-dir awscli==${AWS_VERSION} \
+    && chmod +x /entrypoint.sh
 
-ENTRYPOINT ["/usr/bin/aws"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/aws/entrypoint.sh
+++ b/aws/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Delete an empty AWS environment variable
+unset `env | grep '^AWS_.*=$' | sed 's/=$//'`
+
+exec /usr/bin/aws $@


### PR DESCRIPTION
Set an empty environment variable with variant or aliases.

```
env:
  AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
  AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
  AWS_PROFILE: $AWS_PROFILE
  AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
```

However, the AWS command fails with an empty environment variable.
when the environment variable is empty it is fixed to unset.