### PR TITLE
[aws] fixes exec $@ -> "$@"

### DIFF
--- a/aws/entrypoint.sh
+++ b/aws/entrypoint.sh
@@ -3,4 +3,4 @@
 # Delete an empty AWS environment variable
 unset `env | grep '^AWS_.*=$' | sed 's/=$//'`
 
-exec /usr/bin/aws $@
+exec /usr/bin/aws "$@"


### PR DESCRIPTION
When passing a character string including a space, there is a problem that it is decomposed and passed.
https://fumiyas.github.io/2016/12/15/positional-parameters.sh-advent-calendar.html