### PR TITLE
Add chatwork-web-assets-builder

### DIFF
--- a/chatwork-web-assets-builder/Dockerfile
+++ b/chatwork-web-assets-builder/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:7.1-cli-alpine
+
+LABEL version="0.0.0"
+
+RUN apk --no-cache add openjdk8-jre-base libc6-compat php7-dev g++ gcc make
+
+RUN pecl install swoole \
+    && echo "extension=swoole.so" > /usr/local/etc/php/conf.d/swoole.ini

--- a/chatwork-web-assets-builder/Makefile
+++ b/chatwork-web-assets-builder/Makefile
@@ -1,0 +1,31 @@
+.PHONY: build
+build:
+	docker build -t chatwork/`basename $$PWD` .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -n "$$version" ]; then \
+			docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml run --rm sut;
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push chatwork/`basename $$PWD`:latest; \
+			docker tag chatwork/`basename $$PWD` chatwork/`basename $$PWD`:$$version; \
+			docker push chatwork/`basename $$PWD`:$$version; \
+		fi

--- a/chatwork-web-assets-builder/README.md
+++ b/chatwork-web-assets-builder/README.md
@@ -1,0 +1,20 @@
+# chatwork_web assets builder
+
+https://github.com/chatwork/chatwork_web/tree/develop/assets/build_tool
+
+## Usage
+
+```sh
+$ docker run --rm -it chatwork/assets-builder php -v
+PHP 7.1.26 (cli) (built: Jan 31 2019 01:06:23) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
+
+$ docker run --rm -it chatwork/assets-builder php -m | grep swoole
+swoole
+
+$ docker run --rm -it chatwork/assets-builder java -version
+openjdk version "1.8.0_191"
+OpenJDK Runtime Environment (IcedTea 3.10.0) (Alpine 8.191.12-r0)
+OpenJDK 64-Bit Server VM (build 25.191-b12, mixed mode)
+```

--- a/chatwork-web-assets-builder/docker-compose.test.yml
+++ b/chatwork-web-assets-builder/docker-compose.test.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  busybox:
+    build:
+      context: .
+    image: chatwork/chatwork-web-assets-builder
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run chatwork/chatwork-web-assets-builder tail -f /dev/null
+    volumes:
+      - ./goss/goss.yaml:/goss/goss.yaml
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/chatwork-web-assets-builder/goss/goss.yaml
+++ b/chatwork-web-assets-builder/goss/goss.yaml
@@ -1,0 +1,9 @@
+command:
+  php -v:
+    exit-status: 0
+    stdout:
+      - /^PHP 7.[1-9].+/ # PHP 7.1 and above
+  php -m | grep swoole:
+    exit-status: 0
+  java -version:
+    exit-status: 0


### PR DESCRIPTION
## 目的

* chatwork_web/assets をビルドする環境をコンテナ化。
https://github.com/chatwork/chatwork_web/tree/develop/assets/build_tool
* `chatwork/php-fpm` をベースに openjdk や swoole のインストールを行っていたが、ビルドの度に時間がかかるのでイメージにしておく。
* appbox ビルド時の下記ステージで利用予定。
https://github.com/chatwork/chatwork_web/blob/develop/dockerfiles/appbox/Dockerfile#L23