### PR TITLE
[aws] add groff

### DIFF
--- a/aws/Dockerfile
+++ b/aws/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="ozaki@chatwork.com"
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk --no-cache add py3-pip jq \
+RUN apk --no-cache add py3-pip groff jq \
     && pip3 install --no-cache-dir --upgrade pip \
     && pip3 install --no-cache-dir awscli==${AWS_VERSION} \
     && chmod +x /entrypoint.sh

--- a/aws/goss/goss.yaml
+++ b/aws/goss/goss.yaml
@@ -10,5 +10,7 @@ command:
     exit-status: 0
     stdout:
       - aws-cli/1.16.132
+  /usr/bin/aws help:
+    exit-status: 0
   /usr/bin/jq --version:
     exit-status: 0


### PR DESCRIPTION
```
$ docker run chatwork/aws help    

Could not find executable named "groff"
```

fixed problem that caused an error with `help`.
