### PR TITLE
add gatling-s3-reporter

### DIFF
--- a/gatling-s3-reporter/Dockerfile
+++ b/gatling-s3-reporter/Dockerfile
@@ -1,4 +1,34 @@
-FROM busybox:1
+FROM openjdk:8u212-jdk-alpine
 
-LABEL version="0.0.0"
-LABEL maintainer="ozaki@chatwork.com"
+ARG AWS_VERSION=1.16.58
+ARG GATLING_VERSION=2.2.3
+
+LABEL version="0.0.1-gatling$GATLING_VERSION"
+LABEL maintainer="katsuno@chatwork.com"
+
+RUN apk --no-cache add py3-pip jq \
+    && pip3 install --no-cache-dir --upgrade pip \
+    && pip3 install --no-cache-dir awscli==${AWS_VERSION}
+
+WORKDIR /opt
+
+# install gatling
+RUN mkdir -p gatling && \
+  mkdir -p work && \
+  apk add --update wget bash libc6-compat && \
+  mkdir -p /tmp/downloads && \
+  wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
+  https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
+  mkdir -p /tmp/archive && cd /tmp/archive && \
+  unzip /tmp/downloads/gatling-$GATLING_VERSION.zip && \
+  mv /tmp/archive/gatling-charts-highcharts-bundle-$GATLING_VERSION/* /opt/gatling/ && \
+  rm -rf /tmp/*
+
+# change context to gatling directory
+WORKDIR  /opt/work
+
+ENV GATLING_HOME /opt/gatling
+
+COPY generate-report.sh /generate-report.sh
+
+ENTRYPOINT ["/generate-report.sh"]

--- a/gatling-s3-reporter/Dockerfile
+++ b/gatling-s3-reporter/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox:1
+
+LABEL version="0.0.0"
+LABEL maintainer="ozaki@chatwork.com"

--- a/gatling-s3-reporter/Makefile
+++ b/gatling-s3-reporter/Makefile
@@ -1,0 +1,31 @@
+.PHONY: build
+build:
+	docker build -t chatwork/`basename $$PWD` .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -n "$$version" ]; then \
+			docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml run --rm sut;
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push chatwork/`basename $$PWD`:latest; \
+			docker tag chatwork/`basename $$PWD` chatwork/`basename $$PWD`:$$version; \
+			docker push chatwork/`basename $$PWD`:$$version; \
+		fi

--- a/gatling-s3-reporter/README.md
+++ b/gatling-s3-reporter/README.md
@@ -1,3 +1,21 @@
-# example
+# Gatling S3 reporter
 
-This is an example for chatwork/dockerfiles. Please delete it later.
+Generate report page from Gatling logs.
+https://gatling.io/docs/2.2/
+
+Gatling logs must be stored in S3 directory, with filename `*.log`.
+Gatling report page is created on directory which logs are stored. 
+
+## Usage
+
+### basic example
+
+```
+$ docker run -it --rm -v ~/.aws/credentials:/root/.aws/credentials:ro -e S3_GATLING_BUCKET_NAME=[s3_bucket_name] -e S3_GATLING_RESULT_DIR_PATH=[s3_directory] chatwork/gatling-s3-reporter:latest
+```
+
+### Using specific aws profile
+
+```
+$ docker run -it --rm -v ~/.aws/credentials:/root/.aws/credentials:ro -e S3_GATLING_BUCKET_NAME=[s3_bucket_name] -e S3_GATLING_RESULT_DIR_PATH=[s3_directory] -e AWS_PROFILE=[profile_name] chatwork/gatling-s3-reporter:latest
+```

--- a/gatling-s3-reporter/README.md
+++ b/gatling-s3-reporter/README.md
@@ -4,7 +4,7 @@ Generate report page from Gatling logs.
 https://gatling.io/docs/2.2/
 
 Gatling logs must be stored in S3 directory, with filename `*.log`.
-Gatling report page is created on directory which logs are stored. 
+Gatling report page is created on directory where logs are stored.
 
 ## Usage
 

--- a/gatling-s3-reporter/README.md
+++ b/gatling-s3-reporter/README.md
@@ -1,0 +1,3 @@
+# example
+
+This is an example for chatwork/dockerfiles. Please delete it later.

--- a/gatling-s3-reporter/docker-compose.test.yml
+++ b/gatling-s3-reporter/docker-compose.test.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  busybox:
+    build:
+      context: .
+    image: chatwork/gatling-s3-reporter
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run chatwork/gatling-s3-reporter tail -f /dev/null
+    volumes:
+      - ./goss/goss.yaml:/goss/goss.yaml
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/gatling-s3-reporter/generate-report.sh
+++ b/gatling-s3-reporter/generate-report.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+if [ -z $S3_GATLING_BUCKET_NAME ]; then
+  echo "env S3_GATLING_BUCKET_NAME does not exist"
+  exit 1
+fi
+
+if [ -z $S3_GATLING_RESULT_DIR_PATH ]; then
+  echo "env S3_GATLING_RESULT_DIR_PATH does not exist"
+  exit 1
+fi
+
+mkdir -p $S3_GATLING_RESULT_DIR_PATH
+
+# copy logs from s3
+/usr/bin/aws s3 cp s3://${S3_GATLING_BUCKET_NAME}/${S3_GATLING_RESULT_DIR_PATH}/ ${GATLING_HOME}/results/${S3_GATLING_RESULT_DIR_PATH} --recursive --exclude "*" --include "*.log"
+
+# create report
+/opt/gatling/bin/gatling.sh -ro ${S3_GATLING_RESULT_DIR_PATH}
+
+# copy report files to s3 (excluding logs)
+/usr/bin/aws s3 cp ${GATLING_HOME}/results/${S3_GATLING_RESULT_DIR_PATH} s3://${S3_GATLING_BUCKET_NAME}/${S3_GATLING_RESULT_DIR_PATH}/ --recursive --exclude "*.log"
+
+echo [report url] https://${S3_GATLING_BUCKET_NAME}.s3.amazonaws.com/${S3_GATLING_RESULT_DIR_PATH}/index.html

--- a/gatling-s3-reporter/goss/goss.yaml
+++ b/gatling-s3-reporter/goss/goss.yaml
@@ -1,0 +1,3 @@
+command:
+  echo 1:
+    exit-status: 0


### PR DESCRIPTION
For generating Gatling report from Gatling-logs.
This tool uses Amazon S3 as data-store.

Currently, only Gatling 2.2.3 is supported. If necessary, other versions should be added.