### PR TITLE
[gatling-s3-reporter] modify docker-compose.test.yml and update goss.yaml

### DIFF
--- a/gatling-s3-reporter/docker-compose.test.yml
+++ b/gatling-s3-reporter/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
     environment:
       GOSS_FILES_PATH: /goss
       GOSS_FILES_STRATEGY: cp
-    command: /usr/local/bin/dgoss run chatwork/gatling-s3-reporter tail -f /dev/null
+    command: /usr/local/bin/dgoss run --entrypoint tail chatwork/gatling-s3-reporter -f /dev/null
     volumes:
       - ./goss/goss.yaml:/goss/goss.yaml
       - /var/run/docker.sock:/var/run/docker.sock

--- a/gatling-s3-reporter/goss/goss.yaml
+++ b/gatling-s3-reporter/goss/goss.yaml
@@ -1,7 +1,4 @@
 file:
-  /generate-report.sh:
-    exists: true
-    mode: "0755"
   /opt/gatling/bin/gatling.sh:
     exists: true
     mode: "0744"

--- a/gatling-s3-reporter/goss/goss.yaml
+++ b/gatling-s3-reporter/goss/goss.yaml
@@ -1,3 +1,19 @@
+file:
+  /generate-report.sh:
+    exists: true
+    mode: "0755"
+  /opt/gatling/bin/gatling.sh:
+    exists: true
+    mode: "0744"
+  /usr/bin/aws:
+    exists: true
+    mode: "0755"
 command:
-  echo 1:
-    exit-status: 0
+  /generate-report.sh:
+    exit-status: 1
+    stdout:
+      - env S3_GATLING_BUCKET_NAME does not exist
+  S3_GATLING_BUCKET_NAME=xxx /generate-report.sh:
+    exit-status: 1
+    stdout:
+      - env S3_GATLING_RESULT_DIR_PATH does not exist


### PR DESCRIPTION
Modify docker-compose.test.yml because test was failed.
And add some tests.

Below is executed result.
```
% make test
docker-compose -f docker-compose.test.yml run --rm sut;
INFO: Creating docker container
INFO: Copy goss files into container
INFO: Starting docker container
INFO: Container ID: 8a634e6c
INFO: Sleeping for 0.2
INFO: Container health
PID                 USER                TIME                COMMAND
11029               root                0:00                tail -f /dev/null
INFO: Running Tests
File: /usr/bin/aws: exists: matches expectation: [true]
File: /usr/bin/aws: mode: matches expectation: ["0755"]
File: /opt/gatling/bin/gatling.sh: exists: matches expectation: [true]
File: /opt/gatling/bin/gatling.sh: mode: matches expectation: ["0744"]
Command: S3_GATLING_BUCKET_NAME=xxx /generate-report.sh: exit-status: matches expectation: [1]
Command: S3_GATLING_BUCKET_NAME=xxx /generate-report.sh: stdout: matches expectation: [env S3_GATLING_RESULT_DIR_PATH does not exist]
Command: /generate-report.sh: exit-status: matches expectation: [1]
Command: /generate-report.sh: stdout: matches expectation: [env S3_GATLING_BUCKET_NAME does not exist]


Total Duration: 0.005s
Count: 8, Failed: 0, Skipped: 0
INFO: Deleting container
```
