### PR TITLE
[eksctl] fixes build in ci

### DIFF
--- a/eksctl/Dockerfile
+++ b/eksctl/Dockerfile
@@ -5,8 +5,7 @@ ARG EKSCTL_VERSION=0.11.1
 ARG KUBECTL_VERSION=1.15.6
 LABEL version="${EKSCTL_VERSION}"
 
-RUN wget https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_amd64.tar.gz \
-    && tar zxvf eksctl_Linux_amd64.tar.gz
+RUN wget -O - https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_amd64.tar.gz | tar zxvf -
 
 RUN wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 


### PR DESCRIPTION
https://app.circleci.com/jobs/github/chatwork/dockerfiles/7257
```
Step 6/17 : RUN wget https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_amd64.tar.gz     && tar zxvf eksctl_Linux_amd64.tar.gz
 ---> Running in 0f0b1bd16648
Connecting to github.com (140.82.113.4:443)
Connecting to github-production-release-asset-2e65be.s3.amazonaws.com (52.216.166.83:443)
saving to 'eksctl_Linux_amd64.tar.gz'
eksctl_Linux_amd64.t 100% |********************************| 22.0M  0:00:00 ETA
'eksctl_Linux_amd64.tar.gz' saved
eksctl
The command '/bin/sh -c wget https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_amd64.tar.gz     && tar zxvf eksctl_Linux_amd64.tar.gz' returned a non-zero code: 1
make: *** [Makefile:3: build] Error 1
```

It looks like I have race conditions to download and unpack eksctl.
