### PR TITLE
changed to skip duplicate PR in automatic dependency update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,7 @@ jobs:
           command: |
             git config --global user.email "server_admin+cw-circleci@chatwork.com"
             git config --global user.name "CircleCI"
-            ls */variant.mod | xargs -I{} dirname {} | xargs -I{} /bin/bash -c '
-              echo "\n# {}"
-              git checkout master
-              git reset --hard master
-              cd {} && mod up --build --branch 'mod-up-{}' --pull-request --title "[{}] update dependencies"
-            '
+            ls */variant.mod | xargs -I{} dirname {} | xargs -I{} /bin/bash -c 'echo cd {} && echo mod up --build  --pull-request --base master --branch 'mod-up-{}' --title "[{}] update from v{{ .{}.previousVersion }} to {{ .{}.version }}" --skip-on-duplicate-pull-request-title'
       - run:
           name: Notification failed
           command: |


### PR DESCRIPTION
https://github.com/variantdev/mod/releases/tag/v0.8.0
`variantdev/mod` supported the long-awaited duplicate PR skip feature.
