### PR TITLE
fixes failed build in docker hub

### DIFF
--- a/alpine-sdk/hooks/test
+++ b/alpine-sdk/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/argocd-helmfile/hooks/test
+++ b/argocd-helmfile/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/aws/hooks/test
+++ b/aws/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/chatwork-notify/hooks/test
+++ b/chatwork-notify/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/circleci-docker/hooks/test
+++ b/circleci-docker/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/docker-fluentd/hooks/test
+++ b/docker-fluentd/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/eksctl/hooks/test
+++ b/eksctl/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/example/hooks/test
+++ b/example/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/gatling-ecs-client/hooks/test
+++ b/gatling-ecs-client/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/gatling-s3-reporter/hooks/test
+++ b/gatling-s3-reporter/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/helm/hooks/test
+++ b/helm/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/helmfile/Makefile
+++ b/helmfile/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 build:
 	docker build -t chatwork/`basename $$PWD` .;
-	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD` | sed 's/\+dirty//g'); \
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
 		if [ -n "$$version" ]; then \
 			docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
 		fi

--- a/helmfile/hooks/test
+++ b/helmfile/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/jq/hooks/test
+++ b/jq/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/kube-aws/hooks/test
+++ b/kube-aws/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/kube-fluentd-operator/hooks/test
+++ b/kube-fluentd-operator/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/kubectl/hooks/test
+++ b/kubectl/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/mailcatcher/hooks/test
+++ b/mailcatcher/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/newrelic-php-agent/hooks/test
+++ b/newrelic-php-agent/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/openjdk8/hooks/test
+++ b/openjdk8/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/postfix/hooks/test
+++ b/postfix/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/scala-sbt/hooks/test
+++ b/scala-sbt/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/sops/hooks/test
+++ b/sops/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/variant/hooks/test
+++ b/variant/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/yq/hooks/test
+++ b/yq/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test


### PR DESCRIPTION
Fixed an issue that caused the Docker Hub build to stop working with DLC enabled.

## result

https://hub.docker.com/repository/registry-1.docker.io/chatwork/alpine-sdk/builds/a016dfe2-9374-4528-983d-897d3d5d429a