### PR TITLE
downgrade fluentd

### DIFF
--- a/kube-fluentd-operator/Dockerfile
+++ b/kube-fluentd-operator/Dockerfile
@@ -12,9 +12,9 @@ RUN [ -d vendor/github.com ] || make dep; true
 RUN make build VERSION=${KFO_VERSION}
 
 # base file https://github.com/vmware/kube-fluentd-operator/blob/master/base-image/Dockerfile
-FROM fluent/fluentd:v1.8.0-debian-1.0
+FROM fluent/fluentd:v1.7.4-debian-1.0
 
-LABEL version="v1.8.0-v1.11.0"
+LABEL version="v1.7.4-v1.11.0"
 LABEL maintainer="sakamoto@chatwork.com"
 
 USER root

--- a/kube-fluentd-operator/Makefile
+++ b/kube-fluentd-operator/Makefile
@@ -1,6 +1,7 @@
 KFO_VERSION ?= v1.11.0
 REPOSITORY ?= chatwork
 IMAGE ?= $(REPOSITORY)/$(shell basename $$PWD)
+TAG ?= latest
 
 .PHONY: build
 build: clone
@@ -45,3 +46,8 @@ clone: clean
 .PHONY: clean
 clean:
 	/bin/rm -fr kube-fluentd-operator
+
+shell:
+	docker run --entrypoint=/bin/bash \
+	  -ti --rm -v `pwd`:/workspace --net=host \
+	  $(IMAGE):$(TAG)

--- a/kube-fluentd-operator/variant.lock
+++ b/kube-fluentd-operator/variant.lock
@@ -1,6 +1,6 @@
 dependencies:
   fluentd:
-    version: 1.8.0
+    version: 1.7.4
     previousVersion: 1.7.4
   kfo:
     version: 1.11.0

--- a/kube-fluentd-operator/variant.mod
+++ b/kube-fluentd-operator/variant.mod
@@ -20,4 +20,4 @@ dependencies:
     releasesFrom:
       githubTags:
         source: fluent/fluentd
-    version: "> v1.8.0"
+    version: "> v1.7.3"


### PR DESCRIPTION
- fluent-version to `1.8.0`, the following warnings appear a lot, so downgrade fluent-version

```
2019-12-17 08:14:43 +0000 [warn]: #0 Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.engine_factory
2019-12-17 08:14:43 +0000 [warn]: #0 Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.engine_factory
2019-12-17 08:14:43 +0000 [warn]: #0 Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.engine_factory
2019-12-17 08:14:43 +0000 [warn]: #0 Deprecated method: this method is going to be deleted. Use Fluent::MessagePackFactory.engine_factory
```