### PR TITLE
[postfix] use sasl

### DIFF
--- a/postfix/Dockerfile
+++ b/postfix/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.11
 LABEL version="3.4.8"
 LABEL maintainer="ozaki@chatwork.com"
 
-RUN apk --no-cache add postfix
+RUN apk --no-cache add postfix ca-certificates cyrus-sasl-login cyrus-sasl-plain libsasl
 
 COPY main.cf /etc/postfix/main.cf
 COPY entrypoint.sh /entrypont.sh


### PR DESCRIPTION
https://sendgrid.kke.co.jp/docs/Integrate/Mail_Servers/postfix.html
> no mechanism available エラーが発生した場合、一般的にはSASL認証ライブラリがないことを意味します。