### PR TITLE
version up v9.4.0.249 => v9.6.1.256

### DIFF
--- a/newrelic-php-agent/Dockerfile
+++ b/newrelic-php-agent/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.10
 
-ARG NR_VERSION=9.4.0.249
+ARG NR_VERSION=9.6.1.256
 ARG NR_FILE_NAME=newrelic-php5-${NR_VERSION}-linux-musl
 
 LABEL version="${NR_VERSION}"


### PR DESCRIPTION
[https://chatwork.atlassian.net/browse/STRIX-172](https://chatwork.atlassian.net/browse/STRIX-172)
NewrelicのPHP Agentバージョンの最新版 `9.6.1.256` が出たので対応する

### 確認
```
❯ docker run -it chatwork/newrelic-php-agent:latest sh
2020/02/04 19:39:30 (1) Warning: unable to load the system certificate pool; future versions of the PHP agent may not be able to communicate with New Relic unless ca-certificates are installed on this host
2020/02/04 19:39:30.742692 (1) Info: New Relic daemon version 9.6.1.256-b6618b7ea444 [listen="/tmp/.newrelic.sock" startup=init pid=1 ppid=0 uid=0 euid=0 gid=0 egid=0 runtime="go1.9.7" GOMAXPROCS=6 GOOS=linux GOARCH=amd64]
2020/02/04 19:39:30.743492 (1) Info: collector configuration is &{CAFile: CAPath: Proxy:}
2020/02/04 19:39:30.743934 (1) Info: daemon listening on /tmp/.newrelic.sock
```
