### PR TITLE
Change fluentd mod in kube-fluentd-operator

### DIFF
--- a/kube-fluentd-operator/Dockerfile
+++ b/kube-fluentd-operator/Dockerfile
@@ -12,9 +12,9 @@ RUN [ -d vendor/github.com ] || make dep; true
 RUN make build VERSION=${KFO_VERSION}
 
 # base file https://github.com/vmware/kube-fluentd-operator/blob/master/base-image/Dockerfile
-FROM fluent/fluentd:v1.9.2-debian-1.0
+FROM fluent/fluentd:v1.9.3-debian-1.0
 
-LABEL version="v1.9.2-v1.11.0"
+LABEL version="v1.9.3-debian-1.0-v1.11.0"
 LABEL maintainer="sakamoto@chatwork.com"
 
 USER root

--- a/kube-fluentd-operator/Dockerfile.tpl
+++ b/kube-fluentd-operator/Dockerfile.tpl
@@ -12,9 +12,9 @@ RUN [ -d vendor/github.com ] || make dep; true
 RUN make build VERSION=${KFO_VERSION}
 
 # base file https://github.com/vmware/kube-fluentd-operator/blob/master/base-image/Dockerfile
-FROM fluent/fluentd:{{ .fluentd_version }}-debian-1.0
+FROM fluent/fluentd:{{ .fluentd_tag }}
 
-LABEL version="{{ .fluentd_version }}-{{ .kfo_version }}"
+LABEL version="{{ .fluentd_tag }}-{{ .kfo_version }}"
 LABEL maintainer="sakamoto@chatwork.com"
 
 USER root

--- a/kube-fluentd-operator/variant.lock
+++ b/kube-fluentd-operator/variant.lock
@@ -1,7 +1,7 @@
 dependencies:
   fluentd:
-    version: 1.9.2
-    previousVersion: 1.7.4
+    version: 1.9.3-debian-1.0
+    previousVersion: v1.9.1-debian-1.0
   kfo:
     version: 1.11.0
     previousVersion: 1.10.0

--- a/kube-fluentd-operator/variant.mod
+++ b/kube-fluentd-operator/variant.mod
@@ -4,7 +4,7 @@ provisioners:
       source: Dockerfile.tpl
       arguments:
         kfo_version: "v{{ .kfo.version }}"
-        fluentd_version: "v{{ .fluentd.version }}"
+        fluentd_tag: "v{{ .fluentd.version }}"
   textReplace:
     Makefile:
       from: "v{{ .kfo.previousVersion }}"
@@ -18,6 +18,6 @@ dependencies:
     version: "> v1.9.0"
   fluentd:
     releasesFrom:
-      githubTags:
+      dockerImageTags:
         source: fluent/fluentd
-    version: "> v1.7.3"
+    version: "> v1.9.0-debian-1.0"


### PR DESCRIPTION
- fluentd image update is late for version, so I change mod target to imageTag
  - kfo image update error: https://circleci.com/gh/chatwork/dockerfiles/32040?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link