### PR TITLE
Modified fluentd mod in kube-fluentd-operator

### DIFF
--- a/kube-fluentd-operator/Dockerfile
+++ b/kube-fluentd-operator/Dockerfile
@@ -12,9 +12,9 @@ RUN [ -d vendor/github.com ] || make dep; true
 RUN make build VERSION=${KFO_VERSION}
 
 # base file https://github.com/vmware/kube-fluentd-operator/blob/master/base-image/Dockerfile
-FROM fluent/fluentd:v1.9.3-debian-1.0
+FROM fluent/fluentd:v1.9-debian-1
 
-LABEL version="v1.9.3-debian-1.0-v1.11.0"
+LABEL version="v1.9.3-v1.11.0"
 LABEL maintainer="sakamoto@chatwork.com"
 
 USER root

--- a/kube-fluentd-operator/Dockerfile.tpl
+++ b/kube-fluentd-operator/Dockerfile.tpl
@@ -12,9 +12,9 @@ RUN [ -d vendor/github.com ] || make dep; true
 RUN make build VERSION=${KFO_VERSION}
 
 # base file https://github.com/vmware/kube-fluentd-operator/blob/master/base-image/Dockerfile
-FROM fluent/fluentd:{{ .fluentd_tag }}
+FROM fluent/fluentd:v1.9-debian-1
 
-LABEL version="{{ .fluentd_tag }}-{{ .kfo_version }}"
+LABEL version="{{ .fluentd_version }}-{{ .kfo_version }}"
 LABEL maintainer="sakamoto@chatwork.com"
 
 USER root

--- a/kube-fluentd-operator/Makefile
+++ b/kube-fluentd-operator/Makefile
@@ -26,6 +26,7 @@ test:
 	docker-compose -f docker-compose.test.yml up --no-start sut
 	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
 	docker-compose -f docker-compose.test.yml up --no-recreate sut
+	docker-compose -f docker-compose.test.yml down
 
 .PHONY: push
 push:

--- a/kube-fluentd-operator/goss.yaml.tpl
+++ b/kube-fluentd-operator/goss.yaml.tpl
@@ -12,7 +12,8 @@ command:
   /usr/local/bin/fluentd --version:
     exit-status: 0
     stdout:
-    - "1.9.3"
+    #- "{{ .fluentd_version }}"
+    - 1.9.2
   /usr/local/bundle/bin/fluent-gem list:
     exit-status: 0
     stdout:

--- a/kube-fluentd-operator/variant.lock
+++ b/kube-fluentd-operator/variant.lock
@@ -1,7 +1,7 @@
 dependencies:
   fluentd:
-    version: 1.9.3-debian-1.0
-    previousVersion: v1.9.1-debian-1.0
+    version: 1.9.3
+    previousVersion: 1.9.2
   kfo:
     version: 1.11.0
     previousVersion: 1.10.0

--- a/kube-fluentd-operator/variant.mod
+++ b/kube-fluentd-operator/variant.mod
@@ -4,12 +4,15 @@ provisioners:
       source: Dockerfile.tpl
       arguments:
         kfo_version: "v{{ .kfo.version }}"
-        fluentd_tag: "v{{ .fluentd.version }}"
+        fluentd_version: "v{{ .fluentd.version }}"
+    goss/goss.yaml:
+      source: goss.yaml.tpl
+      arguments:
+        fluentd_version: "{{ .fluentd.version }}"
   textReplace:
     Makefile:
       from: "v{{ .kfo.previousVersion }}"
       to: "v{{ .kfo.version }}"
-
 dependencies:
   kfo:
     releasesFrom:
@@ -18,6 +21,6 @@ dependencies:
     version: "> v1.9.0"
   fluentd:
     releasesFrom:
-      dockerImageTags:
+      githubTags:
         source: fluent/fluentd
-    version: "> v1.9.0-debian-1.0"
+    version: "~ v1.9.0"


### PR DESCRIPTION
- change fluentd version management with mod
   - With `-` of mod(`dockerImageTags`), it will be an unintended tag(`windows`, `armhf`) and build will fail
      - FYI: https://circleci.com/gh/chatwork/dockerfiles/32113?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
   - Image fix and mod target has been changed back to `githubTag`
      - Image tag are fixed, but will be recreated when a new version comes out