### PR TITLE
Add protobuf image

### DIFF
--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -1,4 +1,15 @@
-FROM busybox:1
+FROM chatwork/alpine-sdk:3.11
 
-LABEL version="0.0.0"
-LABEL maintainer="ozaki@chatwork.com"
+LABEL version="2.5.0"
+LABEL maintainer="akatsu@chatwork.com"
+
+ENV PROTOBUF_VERSION="2.5.0"
+
+RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev && \
+    mkdir -p /protobuf && \
+    curl -L https://github.com/google/protobuf/archive/v${PROTOBUF_VERSION}.tar.gz | tar xvz --strip-components=1 -C /protobuf && \
+    cd /protobuf && \
+    autoreconf -f -i -Wall,no-obsolete && \
+    ./configure --prefix=/usr --enable-static=no && \
+    make -j2 && \
+    make install

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox:1
+
+LABEL version="0.0.0"
+LABEL maintainer="ozaki@chatwork.com"

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -13,3 +13,4 @@ RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev &&
     ./configure --prefix=/usr --enable-static=no && \
     make -j2 && \
     make install
+ENTRYPOINT [ "/usr/bin/protoc" ]

--- a/protobuf/Dockerfile
+++ b/protobuf/Dockerfile
@@ -1,9 +1,9 @@
 FROM chatwork/alpine-sdk:3.11
 
-LABEL version="2.5.0"
-LABEL maintainer="akatsu@chatwork.com"
-
 ENV PROTOBUF_VERSION="2.5.0"
+
+LABEL version="${PROTOBUF_VERSION}"
+LABEL maintainer="akatsu@chatwork.com"
 
 RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev && \
     mkdir -p /protobuf && \
@@ -13,4 +13,5 @@ RUN apk add --no-cache build-base curl automake autoconf libtool git zlib-dev &&
     ./configure --prefix=/usr --enable-static=no && \
     make -j2 && \
     make install
+
 ENTRYPOINT [ "/usr/bin/protoc" ]

--- a/protobuf/Makefile
+++ b/protobuf/Makefile
@@ -1,0 +1,33 @@
+.PHONY: build
+build:
+	docker build -t chatwork/`basename $$PWD` .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -n "$$version" ]; then \
+			docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml up --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push chatwork/`basename $$PWD`:latest; \
+			docker tag chatwork/`basename $$PWD` chatwork/`basename $$PWD`:$$version; \
+			docker push chatwork/`basename $$PWD`:$$version; \
+		fi

--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -1,3 +1,9 @@
-# example
+# protobuf
 
-This is an example for chatwork/dockerfiles. Please delete it later.
+https://developers.google.com/protocol-buffers
+
+## Usage
+
+```
+docker run --rm -v `pwd`/protobuf/:/protobuf -v `pwd`/generated/:/generated chatwork/protobuf:2.5.0 protoc /protobuf/[YOUR_PROTO_FILE].proto --java_out=/generated/ --proto_path=/protobuf/
+```

--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -5,5 +5,5 @@ https://developers.google.com/protocol-buffers
 ## Usage
 
 ```
-docker run --rm -v `pwd`/protobuf/:/protobuf -v `pwd`/generated/:/generated chatwork/protobuf:2.5.0 protoc /protobuf/[YOUR_PROTO_FILE].proto --java_out=/generated/ --proto_path=/protobuf/
+docker run --rm -v `pwd`/protobuf/:/protobuf -v `pwd`/generated/:/generated chatwork/protobuf:2.5.0 /protobuf/[YOUR_PROTO_FILE].proto --java_out=/generated/ --proto_path=/protobuf/
 ```

--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -1,0 +1,3 @@
+# example
+
+This is an example for chatwork/dockerfiles. Please delete it later.

--- a/protobuf/docker-compose.test.yml
+++ b/protobuf/docker-compose.test.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  busybox:
+    build:
+      context: .
+    image: chatwork/protobuf
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run chatwork/protobuf tail -f /dev/null
+    container_name: example
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/protobuf/docker-compose.test.yml
+++ b/protobuf/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
     environment:
       GOSS_FILES_PATH: /goss
       GOSS_FILES_STRATEGY: cp
-    command: /usr/local/bin/dgoss run chatwork/protobuf tail -f /dev/null
-    container_name: example
+    command: /usr/local/bin/dgoss run --entrypoint '' chatwork/protobuf tail -f /dev/null
+    container_name: protobuf
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/protobuf/goss/goss.yaml
+++ b/protobuf/goss/goss.yaml
@@ -1,0 +1,3 @@
+command:
+  echo 1:
+    exit-status: 0

--- a/protobuf/goss/goss.yaml
+++ b/protobuf/goss/goss.yaml
@@ -1,3 +1,9 @@
+file:
+  /usr/bin/protoc:
+    exists: true
+    mode: "0755"
 command:
-  echo 1:
+  /usr/bin/protoc --version:
     exit-status: 0
+    stdout:
+      - libprotoc 2.5.0

--- a/protobuf/hooks/test
+++ b/protobuf/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test


### PR DESCRIPTION
## Motivation

`protobuf 2.5.0` is a very old version and is no longer maintained by brew.
Therefore, it is useful to have a docker image when you need it.