### PR TITLE
Modify fluentd mod valid version pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: Install mod
           command: |
-            curl -sSL https://github.com/variantdev/mod/releases/download/v0.13.4/mod_0.13.4_linux_386.tar.gz | tar zx -C /tmp
+            curl -sSL https://github.com/variantdev/mod/releases/download/v0.15.0/mod_0.15.0_linux_amd64.tar.gz | tar zx -C /tmp
             sudo mv /tmp/mod /usr/local/bin/mod
             sudo chmod 755 /usr/local/bin/mod
       - run:

--- a/kube-fluentd-operator/variant.lock
+++ b/kube-fluentd-operator/variant.lock
@@ -1,7 +1,7 @@
 dependencies:
   fluentd:
     version: 1.9.3-debian-1.0
-    previousVersion: v1.9.1-debian-1.0
+    previousVersion: 1.9.2-debian-1.0
   kfo:
     version: 1.11.0
     previousVersion: 1.10.0

--- a/kube-fluentd-operator/variant.mod
+++ b/kube-fluentd-operator/variant.mod
@@ -18,6 +18,7 @@ dependencies:
     version: "> v1.9.0"
   fluentd:
     releasesFrom:
+      validVersionPattern: "[0-9]\\.[0-9]+\\.[0-9]-debian-[0-9.]+"
       dockerImageTags:
         source: fluent/fluentd
     version: "> v1.9.0-debian-1.0"


### PR DESCRIPTION
- Bump mod to 0.15.0
- Modified kube-fluentd-operator for `validVersionPattern` with mod 0.15.0