### PR TITLE
[fluent-bit] temporarily changes the S3 plugin repository

### DIFF
--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -4,7 +4,7 @@ ARG FLUENTBIT_SUFFIX
 
 FROM golang:1.14.0-buster AS fluent-bit-go-s3
 
-ARG FLUENTBIT_GO_S3_VERSION="0.6.2"
+ARG FLUENTBIT_GO_S3_VERSION="0.7.0"
 
 ENV CGO_ENABLED=1
 ENV GOOS=linux
@@ -12,7 +12,7 @@ ENV GOARCH=amd64
 ENV GOPATH=/go
 
 RUN mkdir -p /go/src/github.com/cosmo0920 \
-    && git clone --branch v${FLUENTBIT_GO_S3_VERSION} --single-branch https://github.com/cosmo0920/fluent-bit-go-s3.git /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
+    && git clone --branch v${FLUENTBIT_GO_S3_VERSION} --single-branch https://github.com/k-kinzal/fluent-bit-go-s3.git /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
     && cd /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
     && make build
 
@@ -36,7 +36,7 @@ RUN go get -u golang.org/x/lint/golint \
 FROM fluent/fluent-bit:${FLUENTBIT_VERSION}${FLUENTBIT_SUFFIX}
 
 ARG FLUENTBIT_VERSION="1.4.1"
-ARG FLUENTBIT_GO_S3_VERSION="0.6.2"
+ARG FLUENTBIT_GO_S3_VERSION="0.7.0"
 ARG FLUENTBIT_CLOUDWATCH_LOGS_VERSION="1.2.0"
 
 LABEL version="${FLUENTBIT_VERSION}-${FLUENTBIT_GO_S3_VERSION}-${FLUENTBIT_CLOUDWATCH_LOGS_VERSION}"

--- a/fluent-bit/Dockerfile.tpl
+++ b/fluent-bit/Dockerfile.tpl
@@ -12,7 +12,7 @@ ENV GOARCH=amd64
 ENV GOPATH=/go
 
 RUN mkdir -p /go/src/github.com/cosmo0920 \
-    && git clone --branch v${FLUENTBIT_GO_S3_VERSION} --single-branch https://github.com/cosmo0920/fluent-bit-go-s3.git /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
+    && git clone --branch v${FLUENTBIT_GO_S3_VERSION} --single-branch https://github.com/k-kinzal/fluent-bit-go-s3.git /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
     && cd /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
     && make build
 

--- a/fluent-bit/variant.lock
+++ b/fluent-bit/variant.lock
@@ -5,4 +5,5 @@ dependencies:
     version: 1.4.1
     previousVersion: 1.4.0
   s3:
-    version: 0.6.2
+    version: 0.7.0
+    previousVersion: 0.6.2

--- a/fluent-bit/variant.mod
+++ b/fluent-bit/variant.mod
@@ -17,11 +17,11 @@ dependencies:
       dockerImageTags:
         source: fluent/fluent-bit
     version: "> 0.1"
-  s3:
-    releasesFrom:
-      githubReleases:
-        source: cosmo0920/fluent-bit-go-s3
-    version: "> 0.1"
+#  s3:
+#    releasesFrom:
+#      githubReleases:
+#        source: cosmo0920/fluent-bit-go-s3
+#    version: "> 0.1"
   cloudwatch:
     releasesFrom:
       githubReleases:


### PR DESCRIPTION
We've added a few updates on fluent-bit-go-s3.
https://github.com/cosmo0920/fluent-bit-go-s3/pull/24
https://github.com/cosmo0920/fluent-bit-go-s3/pull/26
https://github.com/cosmo0920/fluent-bit-go-s3/pull/27

I don't want to wait for the release, so I changed the temporary repository and used it.

**NOTE: I will revert this PR when v0.7.0 is released.**