### PR TITLE
[kubectl] stop kubectl114 automatic updates && add kubectl117

### DIFF
--- a/kubectl114/variant.lock
+++ b/kubectl114/variant.lock
@@ -1,4 +1,0 @@
-dependencies:
-  kubectl:
-    version: 1.14.10
-    previousVersion: 1.14.9

--- a/kubectl117/Dockerfile
+++ b/kubectl117/Dockerfile
@@ -1,0 +1,18 @@
+FROM chatwork/alpine-sdk:3.10
+
+ARG KUBECTL_VERSION=1.17.6
+
+LABEL version="${KUBECTL_VERSION}"
+LABEL maintainer="ozaki@chatwork.com"
+LABEL maintainer="sakamoto@chatwork.com"
+
+ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+
+RUN chmod +x /usr/local/bin/kubectl
+
+RUN apk --no-cache add python3 py3-pip groff jq \
+    && pip3 install --no-cache-dir --upgrade pip \
+    && pip3 install --no-cache-dir awscli
+
+ENTRYPOINT ["/usr/local/bin/kubectl"]
+CMD ["help"]

--- a/kubectl117/Makefile
+++ b/kubectl117/Makefile
@@ -1,0 +1,33 @@
+IMAGE ?= chatwork/kubectl
+
+.PHONY: build
+build:
+	docker build -t $(IMAGE) .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} $(IMAGE)); \
+		if [ -n "$$version" ]; then \
+			docker tag $(IMAGE):latest $(IMAGE):$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} $(IMAGE)); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml up --build --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} $(IMAGE):latest); \
+		if docker inspect --format='{{index .RepoDigests 0}}' $(IMAGE):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push $(IMAGE):$$version; \
+		fi

--- a/kubectl117/README.md
+++ b/kubectl117/README.md
@@ -1,0 +1,9 @@
+# kubectl
+
+https://kubernetes.io/docs/tasks/
+
+## Usage
+
+```
+$ docker run -v ~/.kube:/root/.kube chatwork/kubectl version
+```

--- a/kubectl117/docker-compose.test.yml
+++ b/kubectl117/docker-compose.test.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  kubectl116:
+    build:
+      context: .
+    image: chatwork/kubectl
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run --entrypoint '' chatwork/kubectl tail -f /dev/null
+    container_name: kubectl117
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - kubectl116

--- a/kubectl117/goss/goss.yaml
+++ b/kubectl117/goss/goss.yaml
@@ -1,0 +1,9 @@
+file:
+  /usr/local/bin/kubectl:
+    exists: true
+    mode: "0711"
+command:
+  /usr/local/bin/kubectl version:
+    exit-status: 1
+    stdout:
+      - v1.17.6

--- a/kubectl117/hooks/test
+++ b/kubectl117/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/kubectl117/variant.lock
+++ b/kubectl117/variant.lock
@@ -1,0 +1,4 @@
+dependencies:
+  kubectl:
+    version: 1.17.6
+    previousVersion: 1.17.5

--- a/kubectl117/variant.mod
+++ b/kubectl117/variant.mod
@@ -12,4 +12,4 @@ dependencies:
     releasesFrom:
       githubReleases:
         source: kubernetes/kubernetes
-    version: "~ 1.14"
+    version: "~ 1.17"


### PR DESCRIPTION
Stop automatic updates on `kubectl114`.
1.18 of kubectl has been released, so I added `kubectl117`.