### PR TITLE
add datadog-agent-with-network

### DIFF
--- a/datadog-agent-with-network/Dockerfile
+++ b/datadog-agent-with-network/Dockerfile
@@ -1,0 +1,12 @@
+ARG DATADOG_VERSION=7.20.2
+
+FROM datadog/agent:${DATADOG_VERSION}
+
+ARG DATADOG_VERSION=7.20.2
+
+LABEL version="${DATADOG_VERSION}"
+LABEL maintainer="ozaki@chatwork.com"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends iproute2 conntrack \
+    && rm -rf /var/lib/apt/lists/*

--- a/datadog-agent-with-network/Makefile
+++ b/datadog-agent-with-network/Makefile
@@ -1,0 +1,31 @@
+.PHONY: build
+build:
+	docker build -t chatwork/`basename $$PWD` .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -n "$$version" ]; then \
+			docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml up --build --no-start --renew-anon-volumes sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push chatwork/`basename $$PWD`; \
+		fi

--- a/datadog-agent-with-network/README.md
+++ b/datadog-agent-with-network/README.md
@@ -1,0 +1,10 @@
+# datadog-agent-with-network
+
+This image is used to collect TCP connection and conntrack metrics when running network integration with the datadog agent.
+This issue is already on [github](https://github.com/DataDog/datadog-agent/issues/4370). I will remove this image if this response is received.
+
+## Usage
+
+```
+$ docker run chatwork/datadog-agent-with-network
+```

--- a/datadog-agent-with-network/docker-compose.test.yml
+++ b/datadog-agent-with-network/docker-compose.test.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  datadog-agent-with-network:
+    build:
+      context: .
+    image: chatwork/datadog-agent-with-network
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run chatwork/datadog-agent-with-network
+    container_name: datadog-agent-with-network
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - datadog-agent-with-network

--- a/datadog-agent-with-network/goss/goss.yaml
+++ b/datadog-agent-with-network/goss/goss.yaml
@@ -1,0 +1,15 @@
+file:
+ /bin/ss:
+   exists: true
+   mode: "0755"
+ /usr/sbin/conntrack:
+   exists: true
+   mode: "0755"
+ /opt/datadog-agent/bin/agent/agent:
+    exists: true
+    mode: "0755"
+command:
+  /opt/datadog-agent/bin/agent/agent version:
+    exit-status: 0
+    stdout:
+      - 7.20.2

--- a/datadog-agent-with-network/hooks/test
+++ b/datadog-agent-with-network/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/datadog-agent-with-network/variant.lock
+++ b/datadog-agent-with-network/variant.lock
@@ -1,0 +1,4 @@
+dependencies:
+  datadog:
+    version: 7.20.2
+    previousVersion: 7.20.1

--- a/datadog-agent-with-network/variant.mod
+++ b/datadog-agent-with-network/variant.mod
@@ -1,0 +1,15 @@
+provisioners:
+  textReplace:
+    Dockerfile:
+      from: "ARG DATADOG_VERSION={{ .datadog.previousVersion }}"
+      to: "ARG DATADOG_VERSION={{ .datadog.version }}"
+    goss/goss.yaml:
+      from: "- {{ .datadog.previousVersion }}"
+      to: "- {{ .datadog.version }}"
+
+dependencies:
+  datadog:
+    releasesFrom:
+      dockerImageTags:
+        source: datadog/agent
+    version: "> 1.0"


### PR DESCRIPTION
## Motivation

To collect TCP connections and conntrack metrics with Datadog's [network integration](https://docs.datadoghq.com/ja/integrations/network/), you need a few commands in the docker image.
However, as they are not part of the official datadog/agent image, we will add the `ss` and `conntrack` commands to the image.

**NOTE: If an official supports this image, we will remove it.**