### PR TITLE
Add gomplate

### DIFF
--- a/gomplate/Dockerfile
+++ b/gomplate/Dockerfile
@@ -1,0 +1,13 @@
+FROM chatwork/alpine-sdk:3.13
+
+ARG GOMPLATE_VERSION=3.8.0
+
+LABEL version="v${GOMPLATE_VERSION}"
+LABEL maintainer="sakamoto@chatwork.com"
+
+ADD https://github.com/hairyhenderson/gomplate/releases/download/v${GOMPLATE_VERSION}/gomplate_linux-amd64 /usr/local/bin/gomplate
+
+RUN chmod 0755 /usr/local/bin/gomplate
+
+ENTRYPOINT ["/usr/local/bin/gomplate"]
+CMD ["-h"]

--- a/gomplate/Makefile
+++ b/gomplate/Makefile
@@ -1,0 +1,31 @@
+.PHONY: build
+build:
+	docker build -t chatwork/`basename $$PWD` .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -n "$$version" ]; then \
+			docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml up --build --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push chatwork/`basename $$PWD`; \
+		fi

--- a/gomplate/README.md
+++ b/gomplate/README.md
@@ -1,0 +1,6 @@
+# gomplate
+
+This image for gomplate(https://github.com/hairyhenderson/gomplate).
+
+Since the official image(https://hub.docker.com/r/hairyhenderson/gomplate) does not contain anything but the gomplate command,
+and is difficult to use, we are creating an image based on chatwork/alpine-sdk.

--- a/gomplate/docker-compose.test.yml
+++ b/gomplate/docker-compose.test.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  gomplate:
+    build:
+      context: .
+    image: chatwork/gomplate
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run --entrypoint '' chatwork/gomplate tail -f /dev/null
+    container_name: gomplate
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - gomplate

--- a/gomplate/goss/goss.yaml
+++ b/gomplate/goss/goss.yaml
@@ -1,0 +1,9 @@
+file:
+  /usr/local/bin/gomplate:
+    exists: true
+    mode: "0755"
+command:
+  /usr/local/bin/gomplate --version:
+    exit-status: 0
+    stdout:
+      - "/gomplate version 3.8.0/"

--- a/gomplate/hooks/test
+++ b/gomplate/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/gomplate/variant.lock
+++ b/gomplate/variant.lock
@@ -1,0 +1,4 @@
+dependencies:
+  gomplate:
+    version: 3.8.0
+    previousVersion: 3.7.0

--- a/gomplate/variant.mod
+++ b/gomplate/variant.mod
@@ -1,0 +1,15 @@
+provisioners:
+  textReplace:
+    Dockerfile:
+      from: "ARG GOMPLATE_VERSION={{ .gomplate.previousVersion }}"
+      to: "ARG GOMPLATE_VERSION={{ .gomplate.version }}"
+    goss/goss.yaml:
+      from: "gomplate version {{ .gomplate.previousVersion }}"
+      to: "gomplate version {{ .gomplate.version }}"
+
+dependencies:
+  gomplate:
+    releasesFrom:
+      githubReleases:
+        source: hairyhenderson/gomplate
+    version: ">= 1.0.0"


### PR DESCRIPTION
- image for https://github.com/hairyhenderson/gomplate/releases
- Since the official image(https://hub.docker.com/r/hairyhenderson/gomplate) does not contain anything but the `gomplate` command,
and is difficult to use, we are creating an image based on chatwork/alpine-sdk.