### PR TITLE
[kafka-connect-mysql] remove entrypoint

### DIFF
--- a/kafka-connect-mysql/Dockerfile
+++ b/kafka-connect-mysql/Dockerfile
@@ -18,5 +18,3 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8083
-
-ENTRYPOINT ["/usr/bin/connect-distributed"]

--- a/kafka-connect-mysql/Dockerfile.tpl
+++ b/kafka-connect-mysql/Dockerfile.tpl
@@ -18,5 +18,3 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8083
-
-ENTRYPOINT ["/usr/bin/connect-distributed"]


### PR DESCRIPTION
https://github.com/chatwork/dockerfiles/pull/693/commits/4cfcb288d5f045c7833354abca09aae6d7e4378e
I removed the `ENTRYPOINT` in this commit.
However, because I did not remove `ENTRYPOINT` in `Dockerfile.tpl`, `ENTRYPOINT` is back.