### PR TITLE
[fluentd] Change Install Order

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,8 +1,8 @@
-ARG FLUENTD_IMAGE_VERSION="1.12.0-debian-1.0"
+ARG FLUENTD_IMAGE_VERSION="1.12.1-debian-1.0"
 
 FROM fluent/fluentd:v${FLUENTD_IMAGE_VERSION}
 
-ARG FLUENTD_VERSION="1.12.0"
+ARG FLUENTD_VERSION="1.12.1"
 
 LABEL version="${FLUENTD_VERSION}"
 LABEL maintainer="ozaki@chatwork.com"

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -27,8 +27,8 @@ RUN buildDeps="make gcc g++ libc-dev ruby-dev" \
     && fluent-gem install fluent-plugin-cloudwatch-logs -v "0.9.4" \
     && fluent-gem install fluent-plugin-aws-elasticsearch-service -v "1.0.0" \
     # gcp plugin
-    && fluent-gem install fluent-plugin-bigquery -v "2.2.0" \
     && fluent-gem install fluent-plugin-google-cloud -v "0.10.4" \
+    && fluent-gem install fluent-plugin-bigquery -v "2.2.0" \
     # other plugin
     && fluent-gem install fluent-plugin-detect-exceptions -v "0.0.13" \
     && SUDO_FORCE_REMOVE=yes \

--- a/fluentd/goss/goss.yaml
+++ b/fluentd/goss/goss.yaml
@@ -2,7 +2,7 @@ command:
   /bin/entrypoint.sh fluentd --version:
     exit-status: 0
     stdout:
-      - "/fluentd 1.12.0/"
+      - "/fluentd 1.12.1/"
   /bin/entrypoint.sh fluentd --dry-run:
     exit-status: 0
     stdout:

--- a/fluentd/variant.lock
+++ b/fluentd/variant.lock
@@ -1,4 +1,4 @@
 dependencies:
   fluentd:
-    version: 1.12.0-debian-1.0
-    previousVersion: 1.11.5-debian-1.0
+    version: 1.12.1-debian-1.0
+    previousVersion: 1.12.0-debian-1.0


### PR DESCRIPTION
changed the order of installation of gcp plugin gem to avoid the error below.

```
ERROR:  Error installing fluent-plugin-google-cloud:
	"generate-api" from google-api-client conflicts with installed executable from google-apis-generator
```

https://app.circleci.com/pipelines/github/chatwork/dockerfiles/72920/workflows/85596b93-3647-456f-9335-b4ada792ccdd/jobs/107227