### PR TITLE
Update prcli docker image used by CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
           when: on_fail
   merge:
     docker:
-      - image: kinzal/pr:0.2.1
+      - image: kinzal/pr:0.2.4
     environment:
       - CIRCLECI_WORKSPACE: /root/project
     steps:


### PR DESCRIPTION
Updates `pr` docker image to the version which contains fix around multiple PRs merge.
  - [Github release note](https://github.com/k-kinzal/pr/releases/tag/v0.2.4)
  - [Docker image link](https://hub.docker.com/layers/kinzal/pr/0.2.4/images/sha256-c44f5398a51cd1c3ac305755d6188f2258256cad641cf7355b0291de2ee82570?context=explore)
