### PR TITLE
[kafka-connect-mysql] Support v6.x

### DIFF
--- a/kafka-connect-mysql-v60/Dockerfile
+++ b/kafka-connect-mysql-v60/Dockerfile
@@ -1,0 +1,19 @@
+ARG KAFKA_CONNECT_VERSION=6.0.2
+
+FROM confluentinc/cp-kafka-connect-base:${KAFKA_CONNECT_VERSION}
+
+ARG KAFKA_CONNECT_VERSION=6.0.2
+ARG MYSQL_CONNECTOR_VERSION=8.0.25
+
+LABEL version="${KAFKA_CONNECT_VERSION}-${MYSQL_CONNECTOR_VERSION}"
+LABEL maintainer="ozaki@chatwork.com"
+LABEL maintainer="murakami@chatwork.com"
+
+USER root
+
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.2.0 \
+    && wget -O /usr/share/java/kafka/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar
+
+USER appuser
+
+EXPOSE 8083

--- a/kafka-connect-mysql-v60/Dockerfile.tpl
+++ b/kafka-connect-mysql-v60/Dockerfile.tpl
@@ -1,0 +1,19 @@
+ARG KAFKA_CONNECT_VERSION={{ .kafka_connect_version }}
+
+FROM confluentinc/cp-kafka-connect-base:${KAFKA_CONNECT_VERSION}
+
+ARG KAFKA_CONNECT_VERSION={{ .kafka_connect_version }}
+ARG MYSQL_CONNECTOR_VERSION={{ .mysql_connector_version }}
+
+LABEL version="${KAFKA_CONNECT_VERSION}-${MYSQL_CONNECTOR_VERSION}"
+LABEL maintainer="ozaki@chatwork.com"
+LABEL maintainer="murakami@chatwork.com"
+
+USER root
+
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.2.0 \
+    && wget -O /usr/share/java/kafka/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar
+
+USER appuser
+
+EXPOSE 8083

--- a/kafka-connect-mysql-v60/Makefile
+++ b/kafka-connect-mysql-v60/Makefile
@@ -1,0 +1,33 @@
+IMAGE ?= chatwork/kafka-connect-mysql
+
+.PHONY: build
+build:
+	docker build -t $(IMAGE) .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} $(IMAGE)); \
+		if [ -n "$$version" ]; then \
+			docker tag $(IMAGE):latest $(IMAGE):$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} $(IMAGE)); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml up --build --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} $(IMAGE):latest); \
+		if docker inspect --format='{{index .RepoDigests 0}}' $(IMAGE):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push $(IMAGE); \
+		fi

--- a/kafka-connect-mysql-v60/README.md
+++ b/kafka-connect-mysql-v60/README.md
@@ -1,0 +1,11 @@
+# kafka connect mysql
+
+https://docs.confluent.io/platform/current/connect/index.html
+
+Kafka Connect v6.0 with support for MySQL Connector.
+
+## Usage
+
+```
+$ docker run -v ${PWD}/my-connector.properties:/etc/kafka/my-connector.properties chatwork/kafka-connect-mysql /etc/kafka/my-connector.properties
+```

--- a/kafka-connect-mysql-v60/docker-compose.test.yml
+++ b/kafka-connect-mysql-v60/docker-compose.test.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  kafka-connect-mysql-v60:
+    build:
+      context: .
+    image: chatwork/kafka-connect-mysql
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run --entrypoint '' chatwork/kafka-connect-mysql tail -f /dev/null
+    container_name: kafka-connect-mysql-v60
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - kafka-connect-mysql-v60

--- a/kafka-connect-mysql-v60/goss/goss.yaml
+++ b/kafka-connect-mysql-v60/goss/goss.yaml
@@ -1,0 +1,5 @@
+file:
+  /usr/bin/connect-distributed:
+    exists: true
+    mode: "0755"
+

--- a/kafka-connect-mysql-v60/variant.lock
+++ b/kafka-connect-mysql-v60/variant.lock
@@ -1,0 +1,11 @@
+dependencies:
+  kackaConnect:
+    version: 6.0.2
+    previousVersion: 5.5.4
+    versions:
+    - 6.0.2
+  mysqlConnector:
+    version: 8.0.25
+    previousVersion: 8.0.24
+    versions:
+    - 8.0.25

--- a/kafka-connect-mysql-v60/variant.mod
+++ b/kafka-connect-mysql-v60/variant.mod
@@ -1,0 +1,23 @@
+provisioners:
+  files:
+    Dockerfile:
+      source: Dockerfile.tpl
+      arguments:
+        kafka_connect_version: "{{ .kackaConnect.version }}"
+        mysql_connector_version: "{{ .mysqlConnector.version }}"
+
+dependencies:
+  kackaConnect:
+    releasesFrom:
+      dockerImageTags:
+        source: confluentinc/cp-kafka-connect-base
+    version: "< 6.1.0"
+  mysqlConnector:
+    releasesFrom:
+      exec:
+        command: sh
+        args:
+          - -c
+          - |
+            curl -sSL https://repo1.maven.org/maven2/mysql/mysql-connector-java/ | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" | sort | uniq
+    version: "> 0.1.0"

--- a/kafka-connect-mysql-v61/Dockerfile
+++ b/kafka-connect-mysql-v61/Dockerfile
@@ -1,0 +1,19 @@
+ARG KAFKA_CONNECT_VERSION=6.1.1
+
+FROM confluentinc/cp-kafka-connect-base:${KAFKA_CONNECT_VERSION}
+
+ARG KAFKA_CONNECT_VERSION=6.1.1
+ARG MYSQL_CONNECTOR_VERSION=8.0.25
+
+LABEL version="${KAFKA_CONNECT_VERSION}-${MYSQL_CONNECTOR_VERSION}"
+LABEL maintainer="ozaki@chatwork.com"
+LABEL maintainer="murakami@chatwork.com"
+
+USER root
+
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.2.0 \
+    && wget -O /usr/share/java/kafka/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar
+
+USER appuser
+
+EXPOSE 8083

--- a/kafka-connect-mysql-v61/Dockerfile.tpl
+++ b/kafka-connect-mysql-v61/Dockerfile.tpl
@@ -1,0 +1,19 @@
+ARG KAFKA_CONNECT_VERSION={{ .kafka_connect_version }}
+
+FROM confluentinc/cp-kafka-connect-base:${KAFKA_CONNECT_VERSION}
+
+ARG KAFKA_CONNECT_VERSION={{ .kafka_connect_version }}
+ARG MYSQL_CONNECTOR_VERSION={{ .mysql_connector_version }}
+
+LABEL version="${KAFKA_CONNECT_VERSION}-${MYSQL_CONNECTOR_VERSION}"
+LABEL maintainer="ozaki@chatwork.com"
+LABEL maintainer="murakami@chatwork.com"
+
+USER root
+
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-jdbc:10.2.0 \
+    && wget -O /usr/share/java/kafka/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.jar
+
+USER appuser
+
+EXPOSE 8083

--- a/kafka-connect-mysql-v61/Makefile
+++ b/kafka-connect-mysql-v61/Makefile
@@ -1,0 +1,33 @@
+IMAGE ?= chatwork/kafka-connect-mysql
+
+.PHONY: build
+build:
+	docker build -t $(IMAGE) .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} $(IMAGE)); \
+		if [ -n "$$version" ]; then \
+			docker tag $(IMAGE):latest $(IMAGE):$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} $(IMAGE)); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml up --build --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} $(IMAGE):latest); \
+		if docker inspect --format='{{index .RepoDigests 0}}' $(IMAGE):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push $(IMAGE); \
+		fi

--- a/kafka-connect-mysql-v61/README.md
+++ b/kafka-connect-mysql-v61/README.md
@@ -1,0 +1,11 @@
+# kafka connect mysql
+
+https://docs.confluent.io/platform/current/connect/index.html
+
+Kafka Connect v6.1 with support for MySQL Connector.
+
+## Usage
+
+```
+$ docker run -v ${PWD}/my-connector.properties:/etc/kafka/my-connector.properties chatwork/kafka-connect-mysql /etc/kafka/my-connector.properties
+```

--- a/kafka-connect-mysql-v61/docker-compose.test.yml
+++ b/kafka-connect-mysql-v61/docker-compose.test.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  kafka-connect-mysql-v61:
+    build:
+      context: .
+    image: chatwork/kafka-connect-mysql
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run --entrypoint '' chatwork/kafka-connect-mysql tail -f /dev/null
+    container_name: kafka-connect-mysql-v61
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - kafka-connect-mysql-v61

--- a/kafka-connect-mysql-v61/goss/goss.yaml
+++ b/kafka-connect-mysql-v61/goss/goss.yaml
@@ -1,0 +1,5 @@
+file:
+  /usr/bin/connect-distributed:
+    exists: true
+    mode: "0755"
+

--- a/kafka-connect-mysql-v61/variant.lock
+++ b/kafka-connect-mysql-v61/variant.lock
@@ -1,0 +1,12 @@
+dependencies:
+  kackaConnect:
+    version: 6.1.1
+    previousVersion: 6.0.2
+    versions:
+    - 6.0.2
+    - 6.1.1
+  mysqlConnector:
+    version: 8.0.25
+    previousVersion: 8.0.24
+    versions:
+    - 8.0.25

--- a/kafka-connect-mysql-v61/variant.mod
+++ b/kafka-connect-mysql-v61/variant.mod
@@ -1,0 +1,23 @@
+provisioners:
+  files:
+    Dockerfile:
+      source: Dockerfile.tpl
+      arguments:
+        kafka_connect_version: "{{ .kackaConnect.version }}"
+        mysql_connector_version: "{{ .mysqlConnector.version }}"
+
+dependencies:
+  kackaConnect:
+    releasesFrom:
+      dockerImageTags:
+        source: confluentinc/cp-kafka-connect-base
+    version: "< 6.2.0"
+  mysqlConnector:
+    releasesFrom:
+      exec:
+        command: sh
+        args:
+          - -c
+          - |
+            curl -sSL https://repo1.maven.org/maven2/mysql/mysql-connector-java/ | grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" | sort | uniq
+    version: "> 0.1.0"

--- a/kafka-connect-mysql/README.md
+++ b/kafka-connect-mysql/README.md
@@ -2,7 +2,7 @@
 
 https://docs.confluent.io/platform/current/connect/index.html
 
-Lightweight Kafka Connect with support for MySQL Connector.
+Lightweight Kafka Connect v5.x with support for MySQL Connector.
 
 ## Usage
 


### PR DESCRIPTION
Added support for Kafka Connect v6.x.

https://docs.confluent.io/platform/current/installation/versions-interoperability.html
Kafka Connect supports different Kafka versions depending on the version.
Also, since each version has a different EOS, I created a directory for each version like in `kubectl`.