### PR TITLE
update sops in argocd-helmfile to 3.7.1 from a 3-years old version

### DIFF
--- a/argocd-helmfile/Dockerfile
+++ b/argocd-helmfile/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && \
 USER argocd
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} && \
-    helm plugin install https://github.com/futuresimple/helm-secrets && \
+    helm plugin install https://github.com/jkroepke/helm-secrets && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     helm plugin install https://github.com/mumoshu/helm-x  && \
     helm plugin install https://github.com/aslafy-z/helm-git.git

--- a/argocd-helmfile/Dockerfile
+++ b/argocd-helmfile/Dockerfile
@@ -11,8 +11,9 @@ ARG HELM_VERSION=v3.5.4
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 ARG KUBECTL_VERSION=1.18.10
-ARG SOPS_VERSION=3.7.1
+ARG SOPS_VERSION=v3.7.1
 ARG HELM_DIFF_VERSION=3.1.3
+ARG HELM_SECRETS_VERSION=3.7.0
 
 # Install tools needed for your repo-server to retrieve & decrypt secrets, render manifests
 # (e.g. curl, awscli, gpg, sops)
@@ -43,7 +44,7 @@ RUN apt-get update && \
 USER argocd
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} && \
-    helm plugin install https://github.com/jkroepke/helm-secrets && \
+    helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION} && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     helm plugin install https://github.com/mumoshu/helm-x  && \
     helm plugin install https://github.com/aslafy-z/helm-git.git

--- a/argocd-helmfile/Dockerfile
+++ b/argocd-helmfile/Dockerfile
@@ -11,7 +11,7 @@ ARG HELM_VERSION=v3.5.4
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 ARG KUBECTL_VERSION=1.18.10
-ARG SOPS_VERSION=3.2.0
+ARG SOPS_VERSION=3.7.1
 ARG HELM_DIFF_VERSION=3.1.3
 
 # Install tools needed for your repo-server to retrieve & decrypt secrets, render manifests

--- a/argocd-helmfile/Dockerfile.tpl
+++ b/argocd-helmfile/Dockerfile.tpl
@@ -11,7 +11,7 @@ ARG HELM_VERSION=v{{ .helm_version }}
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 ARG KUBECTL_VERSION=1.18.10
-ARG SOPS_VERSION=3.2.0
+ARG SOPS_VERSION=3.7.1
 ARG HELM_DIFF_VERSION=3.1.3
 
 # Install tools needed for your repo-server to retrieve & decrypt secrets, render manifests

--- a/argocd-helmfile/Dockerfile.tpl
+++ b/argocd-helmfile/Dockerfile.tpl
@@ -43,7 +43,7 @@ RUN apt-get update && \
 USER argocd
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} && \
-    helm plugin install https://github.com/futuresimple/helm-secrets && \
+    helm plugin install https://github.com/jkroepke/helm-secrets && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     helm plugin install https://github.com/mumoshu/helm-x  && \
     helm plugin install https://github.com/aslafy-z/helm-git.git

--- a/argocd-helmfile/Dockerfile.tpl
+++ b/argocd-helmfile/Dockerfile.tpl
@@ -11,8 +11,9 @@ ARG HELM_VERSION=v{{ .helm_version }}
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 ARG KUBECTL_VERSION=1.18.10
-ARG SOPS_VERSION=3.7.1
+ARG SOPS_VERSION=v3.7.1
 ARG HELM_DIFF_VERSION=3.1.3
+ARG HELM_SECRETS_VERSION=3.7.0
 
 # Install tools needed for your repo-server to retrieve & decrypt secrets, render manifests
 # (e.g. curl, awscli, gpg, sops)
@@ -43,7 +44,7 @@ RUN apt-get update && \
 USER argocd
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} && \
-    helm plugin install https://github.com/jkroepke/helm-secrets && \
+    helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION} && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git && \
     helm plugin install https://github.com/mumoshu/helm-x  && \
     helm plugin install https://github.com/aslafy-z/helm-git.git


### PR DESCRIPTION
this bumps sops version to a recent version and switches helm-secrets to a supported upstream.

unfortunately, the 3 years old 3.2.0 is very buggy, so this looks like an urgent fix.