### PR TITLE
SSS-632: [gatling-ecs-client] update awssdk for javascript

### DIFF
--- a/gatling-ecs-client/Dockerfile
+++ b/gatling-ecs-client/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:6.16.0-slim
+FROM node:16.3.0-slim
 
-LABEL version=0.0.1
+LABEL version=0.1.1
 
 WORKDIR /usr/src/app
 

--- a/gatling-ecs-client/README.md
+++ b/gatling-ecs-client/README.md
@@ -23,7 +23,7 @@ Docker Cmd must contain below procedures.
 * Ecs task (reporter) must be created by cloudformation
   * must use FARGATE
   * must contain container which name is "gatling-s3-reporter"
-    * use Docker Image chatwork/gatling-s3-reporter:0.0.1-gatling2.2.3
+    * use Docker Image chatwork/gatling-s3-reporter:0.1.1
   * Outputs contains task-definition name
 
 As a Example, please copy and modify samples/cloudformation/gatling-ecs.template to create stack.
@@ -61,18 +61,18 @@ As a Example, please copy and modify samples/example.json
 ### basic example
 
 ```
-$ docker run -it --rm -v ~/.aws/credentials:/root/.aws/credentials:ro -v "$PWD"/gatlingEcs.json:/usr/src/app/setting.json chatwork/gatling-ecs-client:0.0.1
+$ docker run -it --rm -v ~/.aws/credentials:/root/.aws/credentials:ro -v "$PWD"/gatlingEcs.json:/usr/src/app/setting.json chatwork/gatling-ecs-client:0.1.1
 ```
 
 ### Using specific aws profile
 
 ```
-$ docker run -it --rm -e AWS_PROFILE="xxxxxxx" -v ~/.aws/credentials:/root/.aws/credentials:ro -v "$PWD"/gatlingEcs.json:/usr/src/app/setting.json chatwork/gatling-ecs-client:0.0.1
+$ docker run -it --rm -e AWS_PROFILE="xxxxxxx" -v ~/.aws/credentials:/root/.aws/credentials:ro -v "$PWD"/gatlingEcs.json:/usr/src/app/setting.json chatwork/gatling-ecs-client:0.1.1
 ```
 
 ### Using Chatwork API Token to send message when task completed
 
 ```
 $ export CHATWORK_API_TOKEN=xxxxxxxxxxxxxxxxxxx
-$ docker run -it --rm -e AWS_PROFILE="xxxxxxx" -e CHATWORK_API_TOKEN -v ~/.aws/credentials:/root/.aws/credentials:ro -v "$PWD"/gatlingEcs.json:/usr/src/app/setting.json chatwork/gatling-ecs-client:0.0.1
+$ docker run -it --rm -e AWS_PROFILE="xxxxxxx" -e CHATWORK_API_TOKEN -v ~/.aws/credentials:/root/.aws/credentials:ro -v "$PWD"/gatlingEcs.json:/usr/src/app/setting.json chatwork/gatling-ecs-client:0.1.1
 ```

--- a/gatling-ecs-client/package-lock.json
+++ b/gatling-ecs-client/package-lock.json
@@ -1,0 +1,730 @@
+{
+  "name": "gatling-runner",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.0.tgz",
+      "integrity": "sha512-VIpuLRDonMAHgomrsm/zKbeXTnxpr4aHDQmS4pF+NcpvBp64l675yjGA9hyUYs/QJwBjUl8WqMjh9tIRgi85Sg==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.18.0.tgz",
+      "integrity": "sha512-AxDm2QLq2Z+PjzMESB+lPD5XL73MzC4CtUAajPn09ocWj7p9poVN0dd8NVFhBDfQMVPWTQaQBZk7h5TDvZrsBg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/client-cloudformation": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.18.0.tgz",
+      "integrity": "sha512-8l2YPwER/Fqsl/OVMWkzFtw4R5Spsz/H/E0YB0b/Al2INiY0EYcMrL6uH1DkR1J4O/h8ZZ55ccD/WFvaTZEmCA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.18.0",
+        "@aws-sdk/config-resolver": "3.18.0",
+        "@aws-sdk/credential-provider-node": "3.18.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.18.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-signing": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "@aws-sdk/util-waiter": "3.18.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/client-ecs": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.18.0.tgz",
+      "integrity": "sha512-/L2StSEOiXamc7JJt3gouGNn70zdTi9n/TpYwtNdl5NqadOzA0bAbFiQlj9bhW/0N2TjwWEYk9sO6Rqk7aMAgw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.18.0",
+        "@aws-sdk/config-resolver": "3.18.0",
+        "@aws-sdk/credential-provider-node": "3.18.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.18.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-signing": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "@aws-sdk/util-waiter": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.18.0.tgz",
+      "integrity": "sha512-OAS2R13NJ/mNnKxBc//Nva/+BmqaZZrzJ3pHsfGNUvzYE6rNj5iWHACD8LIV/Glf5Z3H52fbwfmYpwkMuvPuXQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.18.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.18.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.18.0.tgz",
+      "integrity": "sha512-xRaBx3A4Edd216ZSZP4360siOx7yGiPY2Ez/w4JbdcwFRjoen8cP9kTgbipgMhbwHVUvgNZpyDrCp0eRHL24bg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.18.0",
+        "@aws-sdk/credential-provider-node": "3.18.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.18.0",
+        "@aws-sdk/middleware-sdk-sts": "3.18.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-signing": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.18.0.tgz",
+      "integrity": "sha512-2uSa/YccHckyYuY0OLDemgb+Jprif/NP+6OW+4eAjkwMGpZ3TtyGXoAZprBHqDXV12QxOYWjL6X6pyHvvsBAsQ==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.18.0.tgz",
+      "integrity": "sha512-+PajLjjpXib9rseqC/r8hnlgq5mOloIaTLYZsdbEC9Afwo5VmYlemL5gAfH+ABxYeanbTvHaP7lUNS3pLrM7dA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.18.0.tgz",
+      "integrity": "sha512-l/yDGjmZkkO0mSqatk7lOHKE6/EGplD5HHgAEY6pr5Y7C5a6ck7/mU7iNtmfq5HAv/YFsXHrewMGyXoE9iQBpg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.18.0.tgz",
+      "integrity": "sha512-Hsef5NC4hPh4BDlin/Eik9S2icFZIvQjPGVL2z3OO30Xer0GHwIQNMAf0WTREQ+cCuXFrIyCwSsdxIo1n2yQnA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.18.0",
+        "@aws-sdk/credential-provider-imds": "3.18.0",
+        "@aws-sdk/credential-provider-web-identity": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.18.0.tgz",
+      "integrity": "sha512-iFwBl6w7mJAFo4YNVL960bkY6c4bUtABtbI+Wka8QbauGTGfAPMlET0JBesPNRAjkB7xzEtujPQL7pz4qlzeNQ==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.18.0",
+        "@aws-sdk/credential-provider-imds": "3.18.0",
+        "@aws-sdk/credential-provider-ini": "3.18.0",
+        "@aws-sdk/credential-provider-process": "3.18.0",
+        "@aws-sdk/credential-provider-sso": "3.18.0",
+        "@aws-sdk/credential-provider-web-identity": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.18.0.tgz",
+      "integrity": "sha512-0KwouUPsAALTqAlzy7HOddujjka3FmlNLe58bPPUk+2nqgg1qKGaNEtDTGCpusIaqLJm7ZbPJ0cJ8B+q/ytuwg==",
+      "requires": {
+        "@aws-sdk/credential-provider-ini": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.18.0.tgz",
+      "integrity": "sha512-EEHnWb/tFvFb9+a7dfChBdHmOZnqZeAbn6TOgc4LME4No9EG3XvkH48wxS0Mdhi9ziEGEdnNLQSVaIFzprWn8w==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.18.0",
+        "@aws-sdk/credential-provider-ini": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.18.0.tgz",
+      "integrity": "sha512-s+F9hE5f2hcrVluEWpDMCSAWUntNQyzJexQKq5KYdJuHsm+oQbACJwWPcB63rbmpzWQht88tU6+YeMRq8P9HIA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.18.0.tgz",
+      "integrity": "sha512-jJS34wJzv+5wumVpQ7fGOmTxkJlu1tmGkbCt13xuSjYpt2M/by+WAShxcxEhrsBJlMNMHTHF+v2Tew6JwEP00w==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/querystring-builder": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.18.0.tgz",
+      "integrity": "sha512-rmjpJl4oG4JxHydnb9F3GzHu5wDJAQswgnBV0NszHfDndJm34f0Dta6OTmreK5nZ8ns/g6ZAjLjiTuKJoxjVmg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-buffer-from": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.18.0.tgz",
+      "integrity": "sha512-+VlXE8G22+H7d6K0EafpmihodOiF8I957J/euWIAGTSYYhLuAXPgCyPoKk1Qmxqfb3oAoG/cuoehCuPfFWwTPA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.18.0.tgz",
+      "integrity": "sha512-HvPRgESVQt0UbzRQZVKhf8SpGGc5Jrln3AtTzkVu6PBHO04Dh2EHsrsxiu7X3oB453Mnp8+LYBVIgsmM/RyJzA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.18.0.tgz",
+      "integrity": "sha512-N1qTzkn+vNjMXBRybW9/S9WtCFiJp2B8agr+41zja4hnZVA07kClvI76jM6KUwQHADB2q79FWT+i6PeyCHHh1Q==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.18.0.tgz",
+      "integrity": "sha512-MPX9GJk3Wl3OjRJ3ti+ptkG+7dTpXGtEjIPF0MsCSlfTKH01lsNGDpSZpeUyhYFrvl3fXoMrPeJHUuFeXA3bIA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.18.0.tgz",
+      "integrity": "sha512-GGiT4w8R7GOvlp4Q1w8JmBaBSsxNUL+ebEcs8ahJBrm9brYZG7tN8ncLXfF7d3oLd5XMoSbBkTn8+dQ973pkEQ==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.18.0.tgz",
+      "integrity": "sha512-PIvbtN05IftmbLACEdV6atNXJVuXNDkK5pcqKgggCteIKHz0QWnLUrgvi9wh2/HqDJD/XpY+ZmOEoZqUnwYSgg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/service-error-classification": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.18.0.tgz",
+      "integrity": "sha512-FVowN386wlLBt7ND5ALbkgJl65ynzxYNBH351mcD2/VwgCx3PZqZSr8sLoVDyuB+X2n9/GAI+r3W++zQ8YOymQ==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/signature-v4": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.18.0.tgz",
+      "integrity": "sha512-46PtAvnGONN/v5OcNE4/3UywadCJunITwXDK/AGs6SMijkOPtoGMjP7fme9XlB6wg4QTSfeF3eKsieOF47RlPg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.18.0.tgz",
+      "integrity": "sha512-0DCwl1Hp66XVG3UUIvBhf7zy8pmeHFATInqRMF91Ch4mYJJdk/U0xLla+ouA2t6SjBkl2tb1bJLgjwkWnvR5Rg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/signature-v4": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.18.0.tgz",
+      "integrity": "sha512-+FDsKMRq3Gsd6ddVt1P+7ltSiRRcEj6KpRccMHkFkFqWWqn9OcPh+Et076ivSBXCW8q9Ib4qJi04hiCD/md2EQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.18.0.tgz",
+      "integrity": "sha512-BGm+buvq0wHtIylYGmyLhuRUvb2MsKx2mBhEx9m5Vs4M8I8GnTgrWtblOzwqZ+Q7dl+GQCL0/tLYTw50BTeLGQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.18.0.tgz",
+      "integrity": "sha512-U+qqNIWivZK9bd1BJMwRyXcTHZAS9r4sgPMrjFyOutdLxBCrhU7QUUr0hFaHdrsVA7cU+D3bBhFxq6JxGmj8Hg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.18.0.tgz",
+      "integrity": "sha512-87ZxGlq3dnlPjAIN0yhawiF+n3oQQihxYaSeysltsuz13X/beYTDyGTEBZXWKwB06O/XHbfBV6iYUR7XgMP20w==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/querystring-builder": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.18.0.tgz",
+      "integrity": "sha512-e7ADhSv8zAePAJLdXT0QItFPnA2ewOCDrD130E0NYA90AnW3xIyLB+J5HbwTWYUcF9Fbo0xSKh+0y8hBjNsT/w==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.18.0.tgz",
+      "integrity": "sha512-GIKvZBEnm87/mRaVYHnsQDYBSvU6qyKjyVdHDpQHhF+MZ+MKafygmpdBjsrRRstWr7h5WepnUVImYgvmaW6vyw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.18.0.tgz",
+      "integrity": "sha512-1DrzflLp80RG674XfhZsl4jehIe0mdSPqXqMH6vOMDcmF/lLEsfwPs307G+Go3kwWXSUup52bcMmfi8Ef4xLBg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-uri-escape": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.18.0.tgz",
+      "integrity": "sha512-7pkgPCeTtsgcgBwYSK2QN9Kij88Adi4bKMBxCqpanloTng2KrZ3DfyyD7c0H70mt21Zqfwr2M1HrPSs1SZKBkw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.18.0.tgz",
+      "integrity": "sha512-bgKy3fl1sIimpXUKqN9Mmb6tRtdtFQDYd/eX0LISSbdtJiVnMgiTxwTPEX72pN54L8zun3zU6xOuwoZP1Af6YA=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.18.0.tgz",
+      "integrity": "sha512-YpBCZWRvJhnPHbdFLzRvLIfx7Zxre8/5YsWrrNNBWRJ90z/6czzPdOn9jab/AVfLPpC/VSSubf4v4b8Cjeb4eA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.18.0.tgz",
+      "integrity": "sha512-md52+v+aIDfhwtaN+xIJ+7XgSqtRmreGkSCnJziGINRSnUSdycoR/ZJhT5d9TbMpYHdoT0Rm9RXNXImlfKCNGw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-hex-encoding": "3.18.0",
+        "@aws-sdk/util-uri-escape": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.18.0.tgz",
+      "integrity": "sha512-fIcfzrf2TnhB4W8UyqdPQ9fPAfIfuLQ0dO/Y9qwzsw0Bvj4qYYPcUaNI2raX7WN1G2KHa9wZdiceR0J+uQO7yg==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.18.0.tgz",
+      "integrity": "sha512-fyk6HXK1wk83n4fDvsG+ewV+yS4uegepeMNrmLr7iBKjzc/bLckTWk7GKFM5ZaF/9jWyk7o2eKW3C3BltgDrfQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.18.0.tgz",
+      "integrity": "sha512-ye3sSF8R6kp1r98MRNk9UDj6P0luQfSZ5N2EZjF8AUG0y4PTVc4L/PlSsH3/sMOjG831al+khNo+cZNO9wZeiQ==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.18.0.tgz",
+      "integrity": "sha512-XG7ls/9utSgCGzD0hgnNAQWLWU9Nnc/IqjQCZ6td84Y1/kTBBafSN3RTPeQ3fLzJ063sTDOy/DPEh21IPZCF6A==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.18.0.tgz",
+      "integrity": "sha512-NzkHCynFU2wfqU/15IkI5H0ukafu//LSUTFp9w4MzFNYpfbXAjcAK4S53VQe46bvciRRk8pyHc4wixiYsxFbpA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.18.0.tgz",
+      "integrity": "sha512-+x0yrV9Z/gGGRVoWmx7t+skwG110vngkq5Clu7z+k/DtuZrkrspYKOVzidaH80pGJwJi+0JzxbIhA5JblBAf7Q==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.18.0.tgz",
+      "integrity": "sha512-r/m+TP9O1G8k9V51LvDCjkoc53Parn7BjP81cBplDrA6Uc2iezVRcjuXzRU+4X8EBIlUtCNhDYryl5xN8cohKw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.18.0.tgz",
+      "integrity": "sha512-4Pp4owEfjNdmqH9cByJnN0GbfM2II3I4FnRN5d9BysJ6mG+rLhc6WYxBgr4sEFtsJGYCgFzLU5MfUMx9OuDdPA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.18.0.tgz",
+      "integrity": "sha512-tayCN0+jLJRyM7W059ybwaEojjI4ylP4UyyG+LDc4m62PskmsCWTWOJzudjtx4d765e0I/F1w1ELrE+VhUdOpQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.18.0.tgz",
+      "integrity": "sha512-Lj2O9KaXCn+gPW23l3ydcSWe4HK0jH6teeSymbaFTwTjKtr4oLfDDKAOFoG5YyppQstEPqsL/RidVey4kOFfcg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.18.0.tgz",
+      "integrity": "sha512-Ui+uydvhzQALj/Q8sat4cVnCedwB/8iBPoMzcm1hr1r7ttWfmBKKElFZFl6ljCUtKaCE3rTb3JrZ2sKy9wT09A==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.18.0.tgz",
+      "integrity": "sha512-qBfyQJqN3RFyeY6nr03RZQ6uT6t5BIdthqwSPZ99K2gvf75TdhPA3PJsaIZfluNHEPQrgrNd32OED8jnd+GXwA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.18.0.tgz",
+      "integrity": "sha512-gSdWW3X0kLMvooo2vc0yqWClclGUqcBfRq0K2w6XhYaJRT4E07KmQa4nPdBMYD1g79xW+53AbdQNnGq8b/bmhA==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.18.0.tgz",
+      "integrity": "sha512-JwcdTb6AAMtnlt2Sg0I18DBK1sWlsfDR/23CkDQ52niXvCSRdHeNkh5b7SdEPVUKI76hyce9nEshzI1OasTv7w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.18.0.tgz",
+      "integrity": "sha512-yQtKkW5V6ycT6DlJkYgeMjj6HJc+jj50LUUx2ukW6IfRmCeAGWdUu82NgIzlzvlsqH1jvmQ/kaeqZ7ruOtmA6Q==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.18.0.tgz",
+      "integrity": "sha512-ba67ZEn96RR7Nm0xXGtxD1ISWsG6ePpnOEi2p6hhP1/zJth70mCgxfMPHbxBmfQuadCtP3lhMGpRIptdAlXnDA==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-timezone": {
+      "version": "0.5.33",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
+    "tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
+}

--- a/gatling-ecs-client/package.json
+++ b/gatling-ecs-client/package.json
@@ -8,7 +8,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.3.16",
-    "moment-timezone": "^0.5.23"
+    "@aws-sdk/client-cloudformation": "^3.18.0",
+    "@aws-sdk/client-ecs": "^3.18.0",
+    "moment-timezone": "^0.5.33"
   }
 }


### PR DESCRIPTION
AWS SDKのアップデート

# 動機
- SSO対応するためには、AWS SDK for Javascript V3を利用する必要がある

# 変更点
- AWS SDK for Javascript V3への変更
- Nodeのバージョンアップ
  - AWS SDK for Javascript V3がnode 6系では動かなかったため（スプレッド演算子が6系で対応してなかった）
- ライブラリのバージョンアップ 
- ラベルの変更
  - ずっと0.0.1も気持ち悪いので、変更しました

# 動作確認

dockerイメージ作成
```
❯ pwd
/Users/cw-ryo.abe/Source/dockerfiles/gatling-ecs-client

❯ make build 
```

gatling起動
```
❯ docker run -it --rm -e AWS_PROFILE=default -v ~/.aws/credentials:/root/.aws/credentials:ro -v "$PWD"/gatlingEcs.json:/usr/src/app/setting.json chatwork/gatling-ecs-client:0.1.1
```
結果
https://cwtest-gatling-logs-all.s3-ap-northeast-1.amazonaws.com/pegasus/pre/20210623174034-1624437634387/index.html