### PR TITLE
SSS-632: [gatling-s3-reporter] update aws cli version

### DIFF
--- a/gatling-s3-reporter/Dockerfile
+++ b/gatling-s3-reporter/Dockerfile
@@ -19,12 +19,12 @@ RUN mkdir -p gatling && \
   unzip /tmp/downloads/gatling-$GATLING_VERSION.zip && \
   mv /tmp/archive/gatling-charts-highcharts-bundle-$GATLING_VERSION/* /opt/gatling/ && \
   rm -rf /tmp/*
- 
+
+# install aws cli to /usr/local/bin/aws
 RUN wget -q -O awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_VERSION}.zip  \
   && unzip -q awscliv2.zip \
   && ./aws/install \
   && rm awscliv2.zip
-
 
 # change context to gatling directory
 WORKDIR  /opt/work
@@ -34,4 +34,3 @@ ENV GATLING_HOME /opt/gatling
 COPY generate-report.sh /generate-report.sh
 
 ENTRYPOINT ["/generate-report.sh"]
-

--- a/gatling-s3-reporter/Dockerfile
+++ b/gatling-s3-reporter/Dockerfile
@@ -1,9 +1,9 @@
 FROM openjdk:8u212-jdk-alpine
 
-ARG AWS_VERSION=1.16.58
+ARG AWS_VERSION=2.2.13
 ARG GATLING_VERSION=3.4.1
 
-LABEL version="0.0.1-gatling$GATLING_VERSION"
+LABEL version="0.1.1-gatling$GATLING_VERSION"
 LABEL maintainer="katsuno@chatwork.com"
 
 RUN apk --no-cache add py3-pip jq \

--- a/gatling-s3-reporter/Dockerfile
+++ b/gatling-s3-reporter/Dockerfile
@@ -6,10 +6,6 @@ ARG GATLING_VERSION=3.4.1
 LABEL version="0.1.1-gatling$GATLING_VERSION"
 LABEL maintainer="katsuno@chatwork.com"
 
-RUN apk --no-cache add py3-pip jq \
-    && pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir awscli==${AWS_VERSION}
-
 WORKDIR /opt
 
 # install gatling
@@ -23,6 +19,12 @@ RUN mkdir -p gatling && \
   unzip /tmp/downloads/gatling-$GATLING_VERSION.zip && \
   mv /tmp/archive/gatling-charts-highcharts-bundle-$GATLING_VERSION/* /opt/gatling/ && \
   rm -rf /tmp/*
+ 
+RUN wget -q -O awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_VERSION}.zip  \
+  && unzip -q awscliv2.zip \
+  && ./aws/install \
+  && rm awscliv2.zip
+
 
 # change context to gatling directory
 WORKDIR  /opt/work

--- a/gatling-s3-reporter/generate-report.sh
+++ b/gatling-s3-reporter/generate-report.sh
@@ -13,12 +13,12 @@ fi
 mkdir -p $S3_GATLING_RESULT_DIR_PATH
 
 # copy logs from s3
-/usr/bin/aws s3 cp s3://${S3_GATLING_BUCKET_NAME}/${S3_GATLING_RESULT_DIR_PATH}/ ${GATLING_HOME}/results/${S3_GATLING_RESULT_DIR_PATH} --recursive --exclude "*" --include "*.log"
+/usr/local/bin/aws s3 cp s3://${S3_GATLING_BUCKET_NAME}/${S3_GATLING_RESULT_DIR_PATH}/ ${GATLING_HOME}/results/${S3_GATLING_RESULT_DIR_PATH} --recursive --exclude "*" --include "*.log"
 
 # create report
 /opt/gatling/bin/gatling.sh -ro ${S3_GATLING_RESULT_DIR_PATH}
 
 # copy report files to s3 (excluding logs)
-/usr/bin/aws s3 cp ${GATLING_HOME}/results/${S3_GATLING_RESULT_DIR_PATH} s3://${S3_GATLING_BUCKET_NAME}/${S3_GATLING_RESULT_DIR_PATH}/ --recursive --exclude "*.log"
+/usr/local/bin/aws s3 cp ${GATLING_HOME}/results/${S3_GATLING_RESULT_DIR_PATH} s3://${S3_GATLING_BUCKET_NAME}/${S3_GATLING_RESULT_DIR_PATH}/ --recursive --exclude "*.log"
 
 echo [report url] https://${S3_GATLING_BUCKET_NAME}.s3.amazonaws.com/${S3_GATLING_RESULT_DIR_PATH}/index.html

--- a/gatling-s3-reporter/goss/goss.yaml
+++ b/gatling-s3-reporter/goss/goss.yaml
@@ -2,7 +2,7 @@ file:
   /opt/gatling/bin/gatling.sh:
     exists: true
     mode: "0744"
-  /usr/bin/aws:
+  /usr/local/bin/aws:
     exists: true
     mode: "0755"
 command:

--- a/gatling-s3-reporter/goss/goss.yaml
+++ b/gatling-s3-reporter/goss/goss.yaml
@@ -4,7 +4,7 @@ file:
     mode: "0744"
   /usr/local/bin/aws:
     exists: true
-    mode: "0755"
+    mode: "0777"
 command:
   /generate-report.sh:
     exit-status: 1


### PR DESCRIPTION
Update AWS cli version for single sign-on.

# 動機
- SSO対応したいので

# 変更点
- AWS CLIのアップデート
- Versionの変更

# 動作確認
- GatlingRunnerと違い、タグを打ってイメージを作成できないため、一時的にDocker Hubに上げる手段がわかっていない。そのため、コンテナイメージのタグ変更を行い、既存のイメージも利用できるようにした上で、CloudFormation側のタグ変更で動作確認を行う予定である。