### PR TITLE
SSS-632: [gatling-s3-reporter] fix glibc install

### DIFF
--- a/gatling-s3-reporter/Dockerfile
+++ b/gatling-s3-reporter/Dockerfile
@@ -2,16 +2,24 @@ FROM openjdk:8u212-jdk-alpine
 
 ARG AWS_VERSION=2.2.13
 ARG GATLING_VERSION=3.4.1
+ARG GLIBC_VER=2.33-r0
 
 LABEL version="0.1.1-gatling$GATLING_VERSION"
 LABEL maintainer="katsuno@chatwork.com"
 
 WORKDIR /opt
 
+# install glibc
+RUN apk --no-cache add binutils curl \
+    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && apk add --no-cache glibc-${GLIBC_VER}.apk glibc-bin-${GLIBC_VER}.apk
+
 # install gatling
 RUN mkdir -p gatling && \
   mkdir -p work && \
-  apk add --update wget bash libc6-compat && \
+  apk add --update wget bash && \
   mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
@@ -25,6 +33,9 @@ RUN wget -q -O awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64
   && unzip -q awscliv2.zip \
   && ./aws/install \
   && rm awscliv2.zip
+
+# aws cli dynamic link check
+RUN aws --version
 
 # change context to gatling directory
 WORKDIR  /opt/work

--- a/gatling-s3-reporter/Dockerfile
+++ b/gatling-s3-reporter/Dockerfile
@@ -10,16 +10,16 @@ LABEL maintainer="katsuno@chatwork.com"
 WORKDIR /opt
 
 # install glibc
-RUN apk --no-cache add binutils curl \
-    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
-    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache glibc-${GLIBC_VER}.apk glibc-bin-${GLIBC_VER}.apk
+RUN apk add --update wget bash \
+    && wget -q https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -O /etc/apk/keys/sgerrand.rsa.pub \
+    && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && apk add --no-cache glibc-${GLIBC_VER}.apk glibc-bin-${GLIBC_VER}.apk \
+    && rm glibc-${GLIBC_VER}.apk glibc-bin-${GLIBC_VER}.apk
 
 # install gatling
 RUN mkdir -p gatling && \
   mkdir -p work && \
-  apk add --update wget bash && \
   mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \

--- a/gatling-s3-reporter/README.md
+++ b/gatling-s3-reporter/README.md
@@ -19,3 +19,10 @@ $ docker run -it --rm -v ~/.aws/credentials:/root/.aws/credentials:ro -e S3_GATL
 ```
 $ docker run -it --rm -v ~/.aws/credentials:/root/.aws/credentials:ro -e S3_GATLING_BUCKET_NAME=[s3_bucket_name] -e S3_GATLING_RESULT_DIR_PATH=[s3_directory] -e AWS_PROFILE=[profile_name] chatwork/gatling-s3-reporter:latest
 ```
+
+### Using AWS sso profile in local environment
+
+```
+$ aws sso login --profile [profile_name]
+$ docker run -it --rm -e AWS_PROFILE=cwtest-sso -v ~/.aws:/root/.aws -e S3_GATLING_BUCKET_NAME=[s3_bucket_name] -e S3_GATLING_RESULT_DIR_PATH=[s3_directory] chatwork/gatling-s3-reporter:latest
+```


### PR DESCRIPTION
# 動機
glibcのインストールをlibc6-compatで入れていたが、awsコマンドを動かす際にシンボル未定義でエラーを吐いてしまった。そのために、glibcをバージョン指定してインストールするように変更する

```
❯ docker run -it --rm -v ~/.aws/credentials:/root/.aws/credentials:ro -e S3_GATLING_BUCKET_NAME=/ecs/logs/gatling-runner-group -e S3_GATLING_RESULT_DIR_PATH=gatling-runner/gatling-s3-reporter/f02575f2409049378fd0ab3d99763893 chatwork/gatling-s3-reporter:latest
Error relocating /usr/local/bin/aws: __strcat_chk: symbol not found
Error relocating /usr/local/bin/aws: __snprintf_chk: symbol not found
Error relocating /usr/local/bin/aws: __vfprintf_chk: symbol not found
Error relocating /usr/local/bin/aws: __realpath_chk: symbol not found
Error relocating /usr/local/bin/aws: __memcpy_chk: symbol not found
Error relocating /usr/local/bin/aws: __vsnprintf_chk: symbol not found
Error relocating /usr/local/bin/aws: __strcpy_chk: symbol not found
Error relocating /usr/local/bin/aws: __fprintf_chk: symbol not found
```
# 変更点
- glibcのインストール
- ドキュメント修正

# 確認
ローカルでイメージをビルドして、動作確認した
```
❯ make build
❯ docker run -it --rm -e AWS_PROFILE=cwtest-sso -v ~/.aws:/root/.aws -e S3_GATLING_BUCKET_NAME=cwtest-gatling-logs-all -e S3_GATLING_RESULT_DIR_PATH=pegasus/pre/20210629153113-1624948273150 chatwork/gatling-s3-reporter:latest   
[report url] https://cwtest-gatling-logs-all.s3.amazonaws.com/pegasus/pre/20210629153113-1624948273150/index.html
```