### PR TITLE
[sbt-ci-openjdk8] Update sbt to 1.5.5 and tools

### DIFF
--- a/sbt-ci-openjdk8/Dockerfile
+++ b/sbt-ci-openjdk8/Dockerfile
@@ -1,31 +1,32 @@
-FROM adoptopenjdk/openjdk8:x86_64-ubuntu-jdk8u252-b09-slim
+FROM adoptopenjdk/openjdk8:jdk8u292-b10-ubuntu-slim
 
-ARG SBT_VERSION=1.3.10
+ARG SBT_VERSION=1.5.5
 
-LABEL version="jdk8u252-b09-$SBT_VERSION"
+LABEL version="jdk8u292-b10-$SBT_VERSION"
 LABEL maintainer="Megumu Katsuno <katsuno@chatwork.com>"
 
 ENV LANG=C.UTF-8
 
-RUN curl -L -o /tmp/sbt.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
-    dpkg -i /tmp/sbt.deb && \
-    rm /tmp/sbt.deb && \
+RUN apt-get update -y && apt-get install -y gnupg2 && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
     apt-get update && \
     apt-get install -y \
     sbt \
     libaio1 \
     git \
     unzip \
-    python \
+    python3 \
     openssh-client && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -o /tmp/awscli-bundle.zip https://s3.amazonaws.com/aws-cli/awscli-bundle.zip && \
-    unzip /tmp/awscli-bundle.zip -d /tmp/ && \
-    /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    rm -rf /tmp/awscli-bundle.zip /tmp/awscli-bundle
+    curl -o /tmp/awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" && \
+    unzip /tmp/awscliv2.zip -d /tmp/ && \
+    /tmp/aws/install -i /usr/local/aws-cli -b /usr/local/bin && \
+    rm -rf /tmp/awscliv2.zip /tmp/aws
 
-RUN curl -o /tmp/docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-19.03.9.tgz && \
+RUN curl -o /tmp/docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-20.10.7.tgz && \
     tar xzvf /tmp/docker.tgz && \
     cp docker/* /usr/bin && \
     rm -rf /tmp/docker.tgz ./docker

--- a/sbt-ci-openjdk8/goss/goss.yaml
+++ b/sbt-ci-openjdk8/goss/goss.yaml
@@ -2,7 +2,7 @@ package:
   sbt:
     installed: true
     versions:
-      - 1.3.10
+      - 1.5.5
   libaio1:
     installed: true
   git:
@@ -19,7 +19,7 @@ command:
   printenv JAVA_VERSION:
     exit-status: 0
     stdout:
-      - "jdk8u252-b09"
+      - "jdk8u292-b10"
     timeout: 5000
   which sbt:
     exit-status: 0


### PR DESCRIPTION
Update tools to

- sbt 1.5.5
- aws cli 2.2.20 (As of 2021-07-20)
- docker 20.10.7

### image size

Image size is bigger than current version.
In my machine:

```
chatwork/sbt-ci-openjdk8    jdk8u292-b10-1.5.5    613e8be878bf   32 minutes ago   733MB
chatwork/sbt-ci-openjdk8    jdk8u252-b09-1.3.10   36032f20daab   13 months ago    579MB
```

The overall size is larger, but the AWS CLI is especially larger.

aws cli v2
```
# du -hs /usr/local/aws-cli
158M	/usr/local/aws-cli
```

aws cli v1 (current)
```
# du -sh /usr/local/aws
95M	/usr/local/aws
```