### PR TITLE
fix dgoss push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,6 @@ jobs:
             docker buildx create --name malti-arch
             docker buildx ls
       - run:
-          name: Add buildx platform
-          command: |
-            docker run --privileged --rm tonistiigi/binfmt --install arm64
-      - run:
           name: build Dockerfile
           command: |
             ARCH=`make arch`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
       - run: make ci:diff
       - run:
           command: |
+            docker buildx ls
+      - run:
+          command: |
             ARCH=`make arch`
             EXTENSION=`make extension`
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,18 +24,18 @@ jobs:
     executor: << parameters.arch >>
     environment:
       - CIRCLECI_WORKSPACE: /home/circleci/project
+      - DOCKER_BUILDKIT: 1
+      - BUILDX_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - checkout
       - run: docker version
       - run: make ci:diff
       - run:
+          name: Install buildx
           command: |
-            docker buildx ls
-      - run:
-          command: |
-            docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
-      - run:
-          command: |
+            docker buildx install
+            docker run --privileged --rm tonistiigi/binfmt --install "$BUILDX_PLATFORMS"
+            docker buildx create --name buildx
             docker buildx ls
       - run:
           command: |
@@ -74,6 +74,10 @@ jobs:
       - run: docker version
       - run: docker login -u="${DOCKER_REGISTRY_USERNAME}" -p="${DOCKER_REGISTRY_PASSWORD}"
       - run: make ci:diff
+      - run:
+          name: Add buildx platform
+          command: |
+            docker run --privileged --rm tonistiigi/binfmt --install arm64
       - run:
           name: build Dockerfile
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,19 +24,10 @@ jobs:
     executor: << parameters.arch >>
     environment:
       - CIRCLECI_WORKSPACE: /home/circleci/project
-      - DOCKER_BUILDKIT: 1
-      - BUILDX_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - checkout
       - run: docker version
       - run: make ci:diff
-      - run:
-          name: Install buildx
-          command: |
-            docker buildx install
-            docker run --privileged --rm tonistiigi/binfmt --install "$BUILDX_PLATFORMS"
-            docker buildx create --name buildx
-            docker buildx ls
       - run:
           command: |
             ARCH=`make arch`
@@ -69,11 +60,20 @@ jobs:
     executor: << parameters.arch >>
     environment:
         - CIRCLECI_WORKSPACE: /home/circleci/project
+        - DOCKER_BUILDKIT: 1
+        - BUILDX_PLATFORMS: linux/amd64,linux/arm64
     steps:
       - checkout
       - run: docker version
       - run: docker login -u="${DOCKER_REGISTRY_USERNAME}" -p="${DOCKER_REGISTRY_PASSWORD}"
       - run: make ci:diff
+      - run:
+          name: Install buildx
+          command: |
+            docker buildx install
+            docker run --privileged --rm tonistiigi/binfmt --install "$BUILDX_PLATFORMS"
+            docker buildx create --name malti-arch
+            docker buildx ls
       - run:
           name: Add buildx platform
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,12 @@ jobs:
             docker buildx ls
       - run:
           command: |
+            docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
+      - run:
+          command: |
+            docker buildx ls
+      - run:
+          command: |
             ARCH=`make arch`
             EXTENSION=`make extension`
 

--- a/dgoss/Dockerfile
+++ b/dgoss/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.8
+FROM docker:20.10.7
 
 ARG GOSS_VERSION=0.3.16
 

--- a/dgoss/Dockerfile.arm64
+++ b/dgoss/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM docker:20.10.8
+FROM docker:20.10.7
 
 ARG GOSS_VERSION=0.3.16
 

--- a/dgoss/Makefile
+++ b/dgoss/Makefile
@@ -13,9 +13,9 @@ esac)
 .PHONY: build
 build:
 	@find . -type f -name "Dockerfile${EXTENSION}" | while read -r FILE; do \
-  		docker buildx use buildx
+  		docker buildx use buildx \
 		docker buildx build -t chatwork/dgoss:test -t chatwork/dgoss --platform linux/amd64,linux/arm64 .; \
-		docker buildx use default
+		docker buildx use default \
 		docker build -f Dockerfile -t chatwork/`basename $$PWD` .; \
       	version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
       	if [ -n "$$version" ]; then \

--- a/dgoss/Makefile
+++ b/dgoss/Makefile
@@ -13,9 +13,6 @@ esac)
 .PHONY: build
 build:
 	@find . -type f -name "Dockerfile${EXTENSION}" | while read -r FILE; do \
-  		docker buildx use buildx \
-		docker buildx build -t chatwork/dgoss:test -t chatwork/dgoss --platform linux/amd64,linux/arm64 .; \
-		docker buildx use default \
 		docker build -f Dockerfile -t chatwork/`basename $$PWD` .; \
       	version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
       	if [ -n "$$version" ]; then \
@@ -44,5 +41,7 @@ push:
 		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
 			echo "no changes"; \
 		else \
+		  	docker buildx use malti-arch; \
 			docker buildx build -t chatwork/dgoss:$$version -t chatwork/dgoss --platform linux/amd64,linux/arm64 --push .; \
+			docker buildx use default; \
 		fi

--- a/dgoss/Makefile
+++ b/dgoss/Makefile
@@ -13,6 +13,9 @@ esac)
 .PHONY: build
 build:
 	@find . -type f -name "Dockerfile${EXTENSION}" | while read -r FILE; do \
+  		docker buildx use buildx
+		docker buildx build -t chatwork/dgoss:test -t chatwork/dgoss --platform linux/amd64,linux/arm64 .; \
+		docker buildx use default
 		docker build -f Dockerfile -t chatwork/`basename $$PWD` .; \
       	version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
       	if [ -n "$$version" ]; then \


### PR DESCRIPTION
I added multiple architecture builds with docker buildx in this pull request, but it was failing to push, so I created [this pull request](https://github.com/chatwork/dockerfiles/pull/924).

The following URL shows the actual build where the push failed.

https://app.circleci.com/pipelines/github/chatwork/dockerfiles/102327/workflows/5ef1f0e5-7fe7-49a2-828e-ec7817b2360d/jobs/137712

This is the builder's configuration in case of failure.

![image](https://user-images.githubusercontent.com/24225197/131836598-f2ce0285-26d9-43da-bf65-afd5c5665fc7.png)

After the fix, it should look like this. This is the workflow for running docker buildx on an existing test job.

https://app.circleci.com/pipelines/github/chatwork/dockerfiles/103611/workflows/e5b9b189-f511-428d-85b3-d901dbd2e467/jobs/139035

Here are the URLs I used for reference.

https://circleci.com/ja/blog/building-docker-images-for-multiple-os-architectures/