### PR TITLE
Create atlantis docker with aws-cli

### DIFF
--- a/atlantis-aws/Dockerfile
+++ b/atlantis-aws/Dockerfile
@@ -1,0 +1,21 @@
+FROM runatlantis/atlantis:v0.14.0
+
+# atlantis version
+LABEL version="0.14.0"
+LABEL maintainer="tatsuno@chatwork.com"
+
+# https://github.com/aws/aws-cli/issues/4685
+ENV GLIBC_VER=2.34-r0
+
+# https://github.com/runatlantis/atlantis/issues/1605#issuecomment-895087882
+RUN curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+    && apk add --update --no-cache util-linux openssl python3 glibc-${GLIBC_VER}.apk glibc-bin-${GLIBC_VER}.apk \
+    && unzip awscliv2.zip && aws/install \
+    && rm -rf awscliv2.zip aws glibc-${GLIBC_VER}.apk glibc-bin-${GLIBC_VER}.apk \
+        /usr/local/aws-cli/v2/*/dist/aws_completer \
+        /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index \
+        /usr/local/aws-cli/v2/*/dist/awscli/examples \
+        /var/cache/apk/* \

--- a/atlantis-aws/Makefile
+++ b/atlantis-aws/Makefile
@@ -1,0 +1,32 @@
+.PHONY: build
+build:
+	docker build -t chatwork/`basename $$PWD` .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+		if [ -n "$$version" ]; then \
+			docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml up --build --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push chatwork/`basename $$PWD`:latest; \
+			docker push chatwork/`basename $$PWD`:$$version; \
+		fi

--- a/atlantis-aws/README.md
+++ b/atlantis-aws/README.md
@@ -1,0 +1,9 @@
+# atlantis-aws
+
+Added [aws-cli](https://aws.amazon.com/jp/cli/) to [runatlantis/atlantis](https://hub.docker.com/r/runatlantis/atlantis)
+
+## Usage
+
+```
+$ docker run -it chatwork/atlantis-aws server --gh-user=X --gh-token=X --repo-whitelist=X
+```

--- a/atlantis-aws/docker-compose.test.yml
+++ b/atlantis-aws/docker-compose.test.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  atlantis-aws:
+    build:
+      context: .
+    image: chatwork/atlantis-aws
+    command:
+      - server
+      - --github-user="X"
+      - --github-token="X"
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run --entrypoint '' chatwork/atlantis-aws tail -f /dev/null
+    container_name: atlantis-aws
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - atlantis-aws

--- a/atlantis-aws/goss/goss.yaml
+++ b/atlantis-aws/goss/goss.yaml
@@ -1,0 +1,17 @@
+file:
+  /usr/local/bin/aws:
+    exists: true
+    mode: "0777"
+  /usr/local/bin/terraform:
+    exists: true
+    mode: "0777"
+  /usr/local/bin/atlantis:
+    exists: true
+    mode: "0755"
+command:
+  /usr/local/bin/aws --version:
+    exit-status: 0
+  /usr/local/bin/terraform --version:
+    exit-status: 0
+  /usr/local/bin/atlantis help:
+    exit-status: 0

--- a/atlantis-aws/hooks/test
+++ b/atlantis-aws/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test


### PR DESCRIPTION
This PR adds a new image to run `atlantis` with `aws`-cli.

`aws`-cli is sometimes needed to create/update AWS resources that is not supported directly by terraform.
An example is to run `create external table` on Athena.
```terraform
resource "null_resource" "foo" {
  provisioner "local-exec" {
    command = <<-EOF
      aws athena start-query-execution \
        --work-group "..." \
        --query-execution-context Database="..." \
        --query-string "..."
    EOF
  }
}
```

Note)
- Latest atlantis version is [0.17.3](https://hub.docker.com/layers/runatlantis/atlantis/v0.17.3/images/sha256-c7505d99062e1be8feb3ba77b6ed4267303c5139425b68396cfd673dbcddaa23?context=explore) but this PR uses `0.14.0` which is run on our environment
