### PR TITLE
[fluent-bit]delete s3 plugin and change golang 1.7 for cloudwatch

### DIFF
--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -1,22 +1,7 @@
-ARG FLUENTBIT_VERSION="1.8.7"
+ARG FLUENTBIT_VERSION="1.8.8"
 ARG FLUENTBIT_SUFFIX
 
-
-FROM golang:1.14.0-buster AS fluent-bit-go-s3
-
-ARG FLUENTBIT_GO_S3_VERSION="0.7.2"
-
-ENV CGO_ENABLED=1
-ENV GOOS=linux
-ENV GOARCH=amd64
-ENV GOPATH=/go
-
-RUN git clone --branch v${FLUENTBIT_GO_S3_VERSION} --single-branch https://github.com/cosmo0920/fluent-bit-go-s3.git /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
-    && cd /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
-    && make build
-
-
-FROM golang:1.12-buster AS amazon-cloudwatch-logs-for-fluent-bit
+FROM golang:1.17-buster AS amazon-cloudwatch-logs-for-fluent-bit
 
 ARG FLUENTBIT_CLOUDWATCH_LOGS_VERSION="1.6.3"
 
@@ -31,17 +16,14 @@ RUN go get -u golang.org/x/lint/golint \
     && cd /go/src/github.com/aws/amazon-cloudwatch-logs-for-fluent-bit \
     && make build
 
-
 FROM fluent/fluent-bit:${FLUENTBIT_VERSION}${FLUENTBIT_SUFFIX}
 
-ARG FLUENTBIT_VERSION="1.8.7"
-ARG FLUENTBIT_GO_S3_VERSION="0.7.2"
+ARG FLUENTBIT_VERSION="1.8.8"
 ARG FLUENTBIT_CLOUDWATCH_LOGS_VERSION="1.6.3"
 
-LABEL version="${FLUENTBIT_VERSION}-${FLUENTBIT_GO_S3_VERSION}-${FLUENTBIT_CLOUDWATCH_LOGS_VERSION}"
+LABEL version="${FLUENTBIT_VERSION}-${FLUENTBIT_CLOUDWATCH_LOGS_VERSION}"
 LABEL maintainer="ozaki@chatwork.com"
 
-COPY --from=fluent-bit-go-s3 /go/src/github.com/cosmo0920/fluent-bit-go-s3/out_s3.so /usr/lib/x86_64-linux-gnu/
 COPY --from=amazon-cloudwatch-logs-for-fluent-bit /go/src/github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/bin/cloudwatch.so /usr/lib/x86_64-linux-gnu/
 
 EXPOSE 2020

--- a/fluent-bit/Dockerfile.tpl
+++ b/fluent-bit/Dockerfile.tpl
@@ -1,22 +1,7 @@
 ARG FLUENTBIT_VERSION="{{ .fluentbit_version }}"
 ARG FLUENTBIT_SUFFIX
 
-
-FROM golang:1.14.0-buster AS fluent-bit-go-s3
-
-ARG FLUENTBIT_GO_S3_VERSION="{{ .fluentbit_s3_version }}"
-
-ENV CGO_ENABLED=1
-ENV GOOS=linux
-ENV GOARCH=amd64
-ENV GOPATH=/go
-
-RUN git clone --branch v${FLUENTBIT_GO_S3_VERSION} --single-branch https://github.com/cosmo0920/fluent-bit-go-s3.git /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
-    && cd /go/src/github.com/cosmo0920/fluent-bit-go-s3 \
-    && make build
-
-
-FROM golang:1.12-buster AS amazon-cloudwatch-logs-for-fluent-bit
+FROM golang:1.17-buster AS amazon-cloudwatch-logs-for-fluent-bit
 
 ARG FLUENTBIT_CLOUDWATCH_LOGS_VERSION="{{ .fluentbit_cloudwatch_version }}"
 
@@ -31,17 +16,14 @@ RUN go get -u golang.org/x/lint/golint \
     && cd /go/src/github.com/aws/amazon-cloudwatch-logs-for-fluent-bit \
     && make build
 
-
 FROM fluent/fluent-bit:${FLUENTBIT_VERSION}${FLUENTBIT_SUFFIX}
 
 ARG FLUENTBIT_VERSION="{{ .fluentbit_version }}"
-ARG FLUENTBIT_GO_S3_VERSION="{{ .fluentbit_s3_version }}"
 ARG FLUENTBIT_CLOUDWATCH_LOGS_VERSION="{{ .fluentbit_cloudwatch_version }}"
 
-LABEL version="${FLUENTBIT_VERSION}-${FLUENTBIT_GO_S3_VERSION}-${FLUENTBIT_CLOUDWATCH_LOGS_VERSION}"
+LABEL version="${FLUENTBIT_VERSION}-${FLUENTBIT_CLOUDWATCH_LOGS_VERSION}"
 LABEL maintainer="ozaki@chatwork.com"
 
-COPY --from=fluent-bit-go-s3 /go/src/github.com/cosmo0920/fluent-bit-go-s3/out_s3.so /usr/lib/x86_64-linux-gnu/
 COPY --from=amazon-cloudwatch-logs-for-fluent-bit /go/src/github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/bin/cloudwatch.so /usr/lib/x86_64-linux-gnu/
 
 EXPOSE 2020

--- a/fluent-bit/README.md
+++ b/fluent-bit/README.md
@@ -6,5 +6,5 @@ In this image, I've added a useful plugin to work with AWS.
 ## Usag
 
 ```
-docker run -v [Your fluent-bit.conf]:/fluent-bit/etc/fluent-bit.conf chatwork/fluent-bit:latest /fluent-bit/bin/fluent-bit -e out_s3.so -e cloudwatch.so -c /fluent-bit/etc/fluent-bit.conf
+docker run -v [Your fluent-bit.conf]:/fluent-bit/etc/fluent-bit.conf chatwork/fluent-bit:latest /fluent-bit/bin/fluent-bit -e cloudwatch.so -c /fluent-bit/etc/fluent-bit.conf
 ```

--- a/fluent-bit/goss/goss.yaml
+++ b/fluent-bit/goss/goss.yaml
@@ -1,7 +1,4 @@
 file:
-  /usr/lib/x86_64-linux-gnu/out_s3.so:
-    exists: true
-    mode: "0644"
   /usr/lib/x86_64-linux-gnu/cloudwatch.so:
     exists: true
     mode: "0644"
@@ -9,4 +6,4 @@ command:
   /fluent-bit/bin/fluent-bit --version:
     exit-status: 0
     stdout:
-      - /v1.8.7/
+      - /v1.8.8/

--- a/fluent-bit/variant.lock
+++ b/fluent-bit/variant.lock
@@ -3,8 +3,5 @@ dependencies:
     version: 1.6.3
     previousVersion: 1.6.2
   fluentbit:
-    version: 1.8.7
-    previousVersion: 1.8.6
-  s3:
-    version: 0.7.2
-    previousVersion: 0.7.1
+    version: 1.8.8
+    previousVersion: 1.8.7

--- a/fluent-bit/variant.mod
+++ b/fluent-bit/variant.mod
@@ -4,7 +4,6 @@ provisioners:
       source: Dockerfile.tpl
       arguments:
         fluentbit_version: "{{ .fluentbit.version }}"
-        fluentbit_s3_version: "{{ .s3.version }}"
         fluentbit_cloudwatch_version: "{{ .cloudwatch.version }}"
   textReplace:
     goss/goss.yaml:
@@ -16,11 +15,6 @@ dependencies:
     releasesFrom:
       dockerImageTags:
         source: fluent/fluent-bit
-    version: "> 0.1"
-  s3:
-    releasesFrom:
-      githubReleases:
-        source: cosmo0920/fluent-bit-go-s3
     version: "> 0.1"
   cloudwatch:
     releasesFrom:


### PR DESCRIPTION
- Delete S3 plugin
  - S3 is difficult to use with fluent-bit(small buffer)
- Change golang 1.17 for cloudwatch 
  - https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit/releases/tag/v1.6.3