### PR TITLE
Add sbt-ci-openjdk11

### DIFF
--- a/sbt-ci-openjdk11/Dockerfile
+++ b/sbt-ci-openjdk11/Dockerfile
@@ -1,0 +1,33 @@
+FROM adoptopenjdk/openjdk11:jdk-11.0.12_7-ubuntu-slim
+ARG SBT_VERSION=1.5.5
+
+LABEL version="jdk-11.0.12-7-$SBT_VERSION"
+LABEL maintainer="shimomura@chatwork.com"
+
+ENV LANG=C.UTF-8
+
+RUN apt-get update -y && apt-get install -y gnupg2 && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
+    apt-get update && \
+    apt-get install -y \
+    sbt=${SBT_VERSION} \
+    libaio1 \
+    git \
+    unzip \
+    python3 \
+    openssh-client && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -o /tmp/awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" && \
+    unzip /tmp/awscliv2.zip -d /tmp/ && \
+    /tmp/aws/install -i /usr/local/aws-cli -b /usr/local/bin && \
+    rm -rf /tmp/awscliv2.zip /tmp/aws
+
+RUN curl -o /tmp/docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-20.10.7.tgz && \
+    tar xzvf /tmp/docker.tgz && \
+    cp docker/* /usr/bin && \
+    rm -rf /tmp/docker.tgz ./docker
+
+WORKDIR /root

--- a/sbt-ci-openjdk11/Makefile
+++ b/sbt-ci-openjdk11/Makefile
@@ -1,0 +1,32 @@
+.PHONY: build
+build:
+	docker build -t chatwork/`basename $$PWD` .;
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -n "$$version" ]; then \
+			docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+		fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml up --build --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker push chatwork/`basename $$PWD`:latest; \
+			docker push chatwork/`basename $$PWD`:$$version; \
+		fi

--- a/sbt-ci-openjdk11/README.md
+++ b/sbt-ci-openjdk11/README.md
@@ -1,0 +1,9 @@
+# sbt-ci-openjdk11
+
+image for running CI jobs for Scala project.
+
+build & test sbt project
+buid docker image
+push image to AWS ECR
+
+https://www.scala-sbt.org/1.x/docs/index.html

--- a/sbt-ci-openjdk11/docker-compose.test.yml
+++ b/sbt-ci-openjdk11/docker-compose.test.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  sbt-ci-openjdk11:
+    build:
+      context: .
+    image: chatwork/sbt-ci-openjdk11
+  sut:
+    image: kiwicom/dgoss
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    command: /usr/local/bin/dgoss run chatwork/sbt-ci-openjdk11 tail -f /dev/null
+    container_name: sbt-ci-openjdk11
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - sbt-ci-openjdk11

--- a/sbt-ci-openjdk11/goss/goss.yaml
+++ b/sbt-ci-openjdk11/goss/goss.yaml
@@ -1,25 +1,37 @@
 package:
-  unzip:
+  sbt:
     installed: true
-  zip:
+    versions:
+      - 1.5.5
+  libaio1:
+    installed: true
+  git:
+    installed: true
+  openssh-client:
     installed: true
 
 command:
   printenv LANG:
     exit-status: 0
     stdout:
-    - "en_US.UTF-8"
+      - "C.UTF-8"
     timeout: 5000
   printenv JAVA_VERSION:
     exit-status: 0
     stdout:
-    - "jdk-11.0.12+7"
+      - "jdk-11.0.12+7"
     timeout: 5000
   which sbt:
     exit-status: 0
     stdout:
-    - "/root/.sdkman/candidates/sbt/current/bin/sbt"
+      - "/usr/bin/sbt"
     timeout: 5000
   java -version:
+    exit-status: 0
+    timeout: 5000
+  aws --version:
+    exit-status: 0
+    timeout: 5000
+  docker --version:
     exit-status: 0
     timeout: 5000


### PR DESCRIPTION
Created docker image of adaptopenjdk 11 series and sbt 1.5.5 for use with CI 

checked versions
```
 docker run -it openjdk11-sbt /bin/bash
root@92b58713dcc9:/tmp# sbt version
[info] welcome to sbt 1.5.5 (Eclipse Foundation Java 11.0.12)
[info] loading project definition from /tmp/project
[info] set current project to tmp (in build file:/tmp/)
[info] 0.1.0-SNAPSHOT
root@92b58713dcc9:/tmp# java -version
openjdk version "11.0.12" 2021-07-20
OpenJDK Runtime Environment Temurin-11.0.12+7 (build 11.0.12+7)
OpenJDK 64-Bit Server VM Temurin-11.0.12+7 (build 11.0.12+7, mixed mode)
```

TODO
- Create docker-hub repository in chatwork