### PR TITLE
add aws-cli-php

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,9 +98,7 @@ jobs:
             make ci:diff | while read DIR; do
               cd ${CIRCLECI_WORKSPACE}/${DIR}
               if find . -type f -name "Dockerfile${EXTENSION}" | grep Dockerfile ; then
-                if [[ "${DIR}" = "aws-cli-php" ]]; then
-                  make push;
-                fi
+                make push;
               else
                 echo "${DIR} is ${ARCH} not supported. make push was skipped.";
               fi
@@ -187,14 +185,11 @@ jobs:
       - run:
           name: update manifest
           command: |
-            make ci:diff
             make ci:diff | while read DIR; do
               if [[ -e "$CIRCLECI_WORKSPACE/$DIR/Dockerfile.arm64" ]] && [[ -e "$CIRCLECI_WORKSPACE/$DIR/Dockerfile" ]] ; then
-                if [[ "${DIR}" = "aws-cli-php" ]]; then
-                  cd ${CIRCLECI_WORKSPACE}/${DIR};
-                  make build;
-                  make manifest:push;
-                fi
+                cd ${CIRCLECI_WORKSPACE}/${DIR};
+                make build;
+                make manifest:push;
               fi
             done
       - run:
@@ -293,7 +288,7 @@ workflows:
             - test
           filters:
             branches:
-              only: add_aws_cli_php
+              only: master
           matrix:
             parameters:
               arch: [ x86_64, arm64 ]
@@ -304,7 +299,7 @@ workflows:
             - push
           filters:
             branches:
-              only: add_aws_cli_php
+              only: master
 
   update_dependecies:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,9 @@ jobs:
             make ci:diff | while read DIR; do
               cd ${CIRCLECI_WORKSPACE}/${DIR}
               if find . -type f -name "Dockerfile${EXTENSION}" | grep Dockerfile ; then
-                make push;
+                if [[ "${DIR}" = "aws-cli-php" ]]; then
+                  make push;
+                fi
               else
                 echo "${DIR} is ${ARCH} not supported. make push was skipped.";
               fi
@@ -172,7 +174,7 @@ jobs:
             sudo mv ./hub-tool/hub-tool /usr/local/bin
 
             expect -c "
-            set timeout 5
+            set timeout 10
             spawn env hub-tool login ${DOCKER_REGISTRY_USERNAME}
             expect \"Password:\"
             send \"${DOCKER_REGISTRY_PASSWORD}\n\"
@@ -188,9 +190,11 @@ jobs:
             make ci:diff
             make ci:diff | while read DIR; do
               if [[ -e "$CIRCLECI_WORKSPACE/$DIR/Dockerfile.arm64" ]] && [[ -e "$CIRCLECI_WORKSPACE/$DIR/Dockerfile" ]] ; then
-                cd ${CIRCLECI_WORKSPACE}/${DIR};
-                make build;
-                make manifest:push;
+                if [[ "${DIR}" = "aws-cli-php" ]]; then
+                  cd ${CIRCLECI_WORKSPACE}/${DIR};
+                  make build;
+                  make manifest:push;
+                fi
               fi
             done
       - run:
@@ -289,7 +293,7 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only: add_aws_cli_php
           matrix:
             parameters:
               arch: [ x86_64, arm64 ]
@@ -300,7 +304,7 @@ workflows:
             - push
           filters:
             branches:
-              only: master
+              only: add_aws_cli_php
 
   update_dependecies:
     jobs:

--- a/aws-cli-php/Dockerfile
+++ b/aws-cli-php/Dockerfile
@@ -1,0 +1,25 @@
+ARG AWS_CLI_VERSION=2.3.5
+ARG PHP_VERSION=8.0
+
+FROM amazon/aws-cli:${AWS_CLI_VERSION}
+
+ARG PHP_VERSION
+ARG AWS_CLI_VERSION
+
+LABEL version="${AWS_CLI_VERSION}-${PHP_VERSION}"
+LABEL aws_cli_version="${AWS_CLI_VERSION}"
+LABEL php_version="${PHP_VERSION}"
+LABEL maintainer="shinohara@chatwork.com"
+
+RUN amazon-linux-extras enable php${PHP_VERSION} \
+    && yum install -y  \
+        jq \
+        git \
+        php \
+        php-mbstring \
+        php-gmp \
+        php-mcrypt \
+        php-xml \
+    && yum clean all
+
+ENTRYPOINT ['/usr/local/bin/aws']

--- a/aws-cli-php/Dockerfile.arm64
+++ b/aws-cli-php/Dockerfile.arm64
@@ -1,0 +1,25 @@
+ARG AWS_CLI_VERSION=2.3.5
+ARG PHP_VERSION=8.0
+
+FROM amazon/aws-cli:${AWS_CLI_VERSION}
+
+ARG PHP_VERSION
+ARG AWS_CLI_VERSION
+
+LABEL version="${AWS_CLI_VERSION}-${PHP_VERSION}"
+LABEL aws_cli_version="${AWS_CLI_VERSION}"
+LABEL php_version="${PHP_VERSION}"
+LABEL maintainer="shinohara@chatwork.com"
+
+RUN amazon-linux-extras enable php${PHP_VERSION} \
+    && yum install -y  \
+        jq \
+        git \
+        php \
+        php-mbstring \
+        php-gmp \
+        php-mcrypt \
+        php-xml \
+    && yum clean all
+
+ENTRYPOINT ['/usr/local/bin/aws']

--- a/aws-cli-php/Makefile
+++ b/aws-cli-php/Makefile
@@ -1,0 +1,87 @@
+ARCH:=$(shell uname -m)
+ENV:="dev"
+LATEST_TAG:=$(shell if [ $(ENV) = "prod" ]; then \
+ 	echo "latest"; \
+ 	else \
+ 		echo "$(ENV)"; \
+ 	fi)
+SCOPE_SUFFIX:=$(shell if [ $(ENV) = "prod" ]; then \
+ 	echo ""; \
+ 	else \
+ 		echo "-$(ENV)"; \
+ 	fi)
+EXTENSION:=$(shell case "$(ARCH)" in \
+	("arm64"|"aarch64") echo ".arm64" ;; \
+	("x86_64") echo "" ;; \
+	(*) echo $(ARCH) ;; \
+esac)
+
+.PHONY: build
+build:
+	@find . -type f -name "Dockerfile${EXTENSION}" | while read -r FILE; do \
+		docker build -f Dockerfile -t chatwork/`basename $$PWD` .; \
+      	version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+        aws_cli_version=$$(docker inspect -f {{.Config.Labels.aws_cli_version}} chatwork/`basename $$PWD`:latest); \
+        php_version=$$(docker inspect -f {{.Config.Labels.php_version}} chatwork/`basename $$PWD`:latest); \
+      	if [ -n "$$version" ] && [ -n "$$aws_cli_version" ] && [ -n "$$php_version" ]; then \
+            docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+        fi \
+    done
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+    aws_cli_version=$$(docker inspect -f {{.Config.Labels.aws_cli_version}} chatwork/`basename $$PWD`:latest); \
+    php_version=$$(docker inspect -f {{.Config.Labels.php_version}} chatwork/`basename $$PWD`:latest); \
+    if [[ -z $$version ]]; then \
+    	echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+    	exit 1; \
+    fi; \
+    if [[ -z $$aws_cli_version ]]; then \
+    	echo "\033[91mError: aws_cli_version is not defined in Dockerfile.\033[0m"; \
+    	exit 1; \
+    fi; \
+    if [[ -z $$php_version ]]; then \
+    	echo "\033[91mError: php_version is not defined in Dockerfile.\033[0m"; \
+    	exit 1; \
+    fi; \
+    echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test:
+	docker-compose -f docker-compose.test.yml up --build --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+	if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+		echo "no changes"; \
+	else \
+		docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version-$(ARCH)$(SCOPE_SUFFIX); \
+		docker push chatwork/`basename $$PWD`:$$version-$(ARCH)$(SCOPE_SUFFIX); \
+	fi
+
+.PHONY: manifest\:push
+manifest\:push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+	if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+	  	echo "no changes"; \
+	else \
+		docker pull chatwork/`basename $$PWD`:$$version-aarch64$(SCOPE_SUFFIX); \
+		docker pull chatwork/`basename $$PWD`:$$version-x86_64$(SCOPE_SUFFIX); \
+		arm64_digest=$$(docker inspect -f '{{index .RepoDigests 0}}' chatwork/`basename $$PWD`:$$version-aarch64$(SCOPE_SUFFIX)); \
+        amd64_digest=$$(docker inspect -f '{{index .RepoDigests 0}}' chatwork/`basename $$PWD`:$$version-x86_64$(SCOPE_SUFFIX)); \
+		docker buildx imagetools create -t chatwork/`basename $$PWD`:$$version$(SCOPE_SUFFIX) $$arm64_digest $$amd64_digest; \
+		docker buildx imagetools create -t chatwork/`basename $$PWD`:$(LATEST_TAG) $$arm64_digest $$amd64_digest; \
+		hub-tool tag rm chatwork/`basename $$PWD`:$$version-aarch64$(SCOPE_SUFFIX) -f; \
+        hub-tool tag rm chatwork/`basename $$PWD`:$$version-x86_64$(SCOPE_SUFFIX) -f; \
+    fi
+
+.PHONY: manifest\:succeed-message
+manifest\:succeed-message:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/aws-cli-php:latest); \
+	echo "Released new tags."; \
+	echo "- chatwork/aws-cli-php:$$version$(SCOPE_SUFFIX)"; \
+	echo "- chatwork/aws-cli-php:$(LATEST_TAG)";

--- a/aws-cli-php/Makefile
+++ b/aws-cli-php/Makefile
@@ -1,5 +1,5 @@
 ARCH:=$(shell uname -m)
-ENV:="dev"
+ENV:="prod"
 LATEST_TAG:=$(shell if [ $(ENV) = "prod" ]; then \
  	echo "latest"; \
  	else \

--- a/aws-cli-php/README.md
+++ b/aws-cli-php/README.md
@@ -1,0 +1,9 @@
+# aws-cli-php
+
+aws-cli-php is an image of [aws-cli](https://hub.docker.com/r/amazon/aws-cli) with php
+
+## Usage
+
+```
+$ docker run -it chatwork/aws-cli-php help
+```

--- a/aws-cli-php/docker-compose.test.yml
+++ b/aws-cli-php/docker-compose.test.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  aws-cli-php:
+    build:
+      context: .
+    image: chatwork/aws-cli-php
+    entrypoint: /bin/bash
+  sut:
+    image: chatwork/dgoss:latest
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    entrypoint: ""
+    command: /usr/local/bin/dgoss run --entrypoint "" chatwork/aws-cli-php tail -f /dev/null
+    container_name: aws-cli-php
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./goss/goss.yaml:/goss/goss.yaml
+    depends_on:
+      - aws-cli-php

--- a/aws-cli-php/goss/goss.yaml
+++ b/aws-cli-php/goss/goss.yaml
@@ -1,0 +1,8 @@
+command:
+  php -v:
+    exit-status: 0
+    stdout:
+      - "/^PHP 8.[0-9]+/"
+
+  aws help:
+    exit-status: 0

--- a/aws-cli-php/variant.lock
+++ b/aws-cli-php/variant.lock
@@ -1,0 +1,4 @@
+dependencies:
+  awscli:
+    version: 2.3.5
+    previousVersion: 2.3.4

--- a/aws-cli-php/variant.mod
+++ b/aws-cli-php/variant.mod
@@ -1,0 +1,18 @@
+provisioners:
+  textReplace:
+    Dockerfile:
+      from: "ARG AWS_CLI_VERSION={{ .awscli.previousVersion }}"
+      to: "ARG AWS_CLI_VERSION={{ .awscli.version }}"
+    Dockerfile.arm64:
+      from: "ARG AWS_CLI_VERSION={{ .awscli.previousVersion }}"
+      to: "ARG AWS_CLI_VERSION={{ .awscli.version }}"
+    goss/goss.yaml:
+      from: "- {{ .awscli.previousVersion }}"
+      to: "- {{ .awscli.version }}"
+
+dependencies:
+  aws-cli:
+    releasesFrom:
+      dockerImageTags:
+        source: amazon/aws-cli
+        version: "> 2.3.5"


### PR DESCRIPTION
This is an image of aws-cli with php.

## Samples

-dev tag is a sample image under development.
https://hub.docker.com/r/chatwork/aws-cli-php/tags

The reason why there are two versions of dev is because the latest version of aws-cli has arrived, and we have tested mod update.

The dev image will be removed when we merge it into main.