### PR TITLE
modify circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
             docker buildx install
             docker run --privileged --rm tonistiigi/binfmt --install "$BUILDX_PLATFORMS"
             docker buildx create --name malti-arch
+            docker buildx create --use
             docker buildx ls
       - run:
           name: build Dockerfile

--- a/alpine-sdk/Dockerfile
+++ b/alpine-sdk/Dockerfile
@@ -3,5 +3,4 @@ FROM alpine:3.15
 LABEL version="3.15"
 LABEL maintainer="sakamoto@chatwork.com"
 
-# test comment
 RUN apk --no-cache add alpine-sdk bash

--- a/alpine-sdk/Dockerfile.arm64
+++ b/alpine-sdk/Dockerfile.arm64
@@ -3,5 +3,4 @@ FROM alpine:3.15
 LABEL version="3.15"
 LABEL maintainer="sakamoto@chatwork.com"
 
-# test comment
 RUN apk --no-cache add alpine-sdk bash


### PR DESCRIPTION
Added the command(docker buildx...) shown in the following message
```
error: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
make: *** [Makefile:41: push] Error 1
```
