### PR TITLE
add provider-terraform-controller

### DIFF
--- a/provider-terraform-controller/Dockerfile
+++ b/provider-terraform-controller/Dockerfile
@@ -1,0 +1,19 @@
+ARG CROSSPLANE_PROVIDER_TERRAFORM_VERSION=0.2.0
+
+FROM crossplane/provider-terraform-controller:v${CROSSPLANE_PROVIDER_TERRAFORM_VERSION}
+
+ARG CROSSPLANE_PROVIDER_TERRAFORM_VERSION=0.2.0
+ARG TERRAFORM_VERSION=1.2.1
+
+LABEL version="${CROSSPLANE_PROVIDER_TERRAFORM_VERSION}-${TERRAFORM_VERSION}"
+LABEL maintainer="ozaki@chatwork.com"
+
+USER root
+
+RUN cd /tmp \
+    && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && mv terraform /usr/local/bin/ \
+    && rm -f /tmp/*
+
+USER 2000

--- a/provider-terraform-controller/Dockerfile.tpl
+++ b/provider-terraform-controller/Dockerfile.tpl
@@ -1,0 +1,19 @@
+ARG CROSSPLANE_PROVIDER_TERRAFORM_VERSION={{ .provider_terraform_version }}
+
+FROM crossplane/provider-terraform-controller:v${CROSSPLANE_PROVIDER_TERRAFORM_VERSION}
+
+ARG CROSSPLANE_PROVIDER_TERRAFORM_VERSION={{ .provider_terraform_version }}
+ARG TERRAFORM_VERSION={{ .terraform_version }}
+
+LABEL version="${CROSSPLANE_PROVIDER_TERRAFORM_VERSION}-${TERRAFORM_VERSION}"
+LABEL maintainer="ozaki@chatwork.com"
+
+USER root
+
+RUN cd /tmp \
+    && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+    && mv terraform /usr/local/bin/ \
+    && rm -f /tmp/*
+
+USER 2000

--- a/provider-terraform-controller/Makefile
+++ b/provider-terraform-controller/Makefile
@@ -1,0 +1,54 @@
+ARCH:=$(shell uname -m)
+TAG:=$(shell case "$(ARCH)" in \
+	("arm64"|"aarch64") echo "arm64" ;; \
+	("x86_64") echo "x86_64" ;; \
+	(*) echo $(ARCH) ;; \
+esac)
+EXTENSION:=$(shell case "$(ARCH)" in \
+	("arm64"|"aarch64") echo ".arm64" ;; \
+	("x86_64") echo "" ;; \
+	(*) echo $(ARCH) ;; \
+esac)
+
+.PHONY: build
+build:
+	@find . -type f -name "Dockerfile${EXTENSION}" | while read -r FILE; do \
+		docker build -f Dockerfile${EXTENSION} -t chatwork/`basename $$PWD` .; \
+      	version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+      	if [ -n "$$version" ]; then \
+            docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version-${TAG}; \
+        fi \
+    done
+
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test: build
+	docker-compose -f docker-compose.test.yml up --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker buildx build -t chatwork/`basename $$PWD`:$$version -t chatwork/`basename $$PWD` --platform linux/amd64,linux/arm64 --push .; \
+		fi
+
+.PHONY: manifest\:push
+manifest\:push:
+	@echo "Manifest push skipped, because this image use buildx."
+
+.PHONY: manifest\:succeed-message
+manifest\:succeed-message:
+	@echo "Manifest push skipped, because this image use buildx."

--- a/provider-terraform-controller/README.md
+++ b/provider-terraform-controller/README.md
@@ -1,0 +1,6 @@
+# provider-terraform-controller
+
+https://github.com/crossplane-contrib/provider-terraform
+https://hub.docker.com/r/crossplane/provider-terraform-controller
+
+The original image is an older version of terraform and has been modified to use the latest version.

--- a/provider-terraform-controller/docker-compose.test.yml
+++ b/provider-terraform-controller/docker-compose.test.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  provider_terraform_controller:
+    build:
+      context: .
+    image: chatwork/provider-terraform-controller
+  sut:
+    image: chatwork/dgoss:latest
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    entrypoint: ""
+    command: /usr/local/bin/dgoss run --entrypoint '' chatwork/provider-terraform-controller tail -f /dev/null
+    container_name: provider-terraform-controller
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - provider_terraform_controller

--- a/provider-terraform-controller/goss/goss.yaml
+++ b/provider-terraform-controller/goss/goss.yaml
@@ -1,0 +1,12 @@
+file:
+  /usr/local/bin/crossplane-terraform-provider:
+    exists: true
+    mode: "0755"
+  /usr/local/bin/terraform:
+    exists: true
+    mode: "0755"
+command:
+  /usr/local/bin/terraform version:
+    exit-status: 0
+    stdout:
+      - Terraform v1.2.1

--- a/provider-terraform-controller/variant.lock
+++ b/provider-terraform-controller/variant.lock
@@ -1,0 +1,120 @@
+dependencies:
+  provider_terraform:
+    version: 0.2.0
+    versions:
+    - 0.2.0
+  terraform:
+    version: 1.2.1
+    previousVersion: 1.2.0
+    versions:
+    - 1.2.1
+    githubRelease:
+      assets: []
+      assets_url: https://api.github.com/repos/hashicorp/terraform/releases/67611650/assets
+      author:
+        avatar_url: https://avatars.githubusercontent.com/u/82990137?v=4
+        events_url: https://api.github.com/users/hc-github-team-tf-core/events{/privacy}
+        followers_url: https://api.github.com/users/hc-github-team-tf-core/followers
+        following_url: https://api.github.com/users/hc-github-team-tf-core/following{/other_user}
+        gists_url: https://api.github.com/users/hc-github-team-tf-core/gists{/gist_id}
+        gravatar_id: ""
+        html_url: https://github.com/hc-github-team-tf-core
+        id: 82990137
+        login: hc-github-team-tf-core
+        node_id: MDQ6VXNlcjgyOTkwMTM3
+        organizations_url: https://api.github.com/users/hc-github-team-tf-core/orgs
+        received_events_url: https://api.github.com/users/hc-github-team-tf-core/received_events
+        repos_url: https://api.github.com/users/hc-github-team-tf-core/repos
+        site_admin: false
+        starred_url: https://api.github.com/users/hc-github-team-tf-core/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/hc-github-team-tf-core/subscriptions
+        type: User
+        url: https://api.github.com/users/hc-github-team-tf-core
+      body: "## 1.2.1 (May 23, 2022)\r\n\r\nBUG FIXES:\r\n\r\n* SSH provisioner connections
+        fail when using signed `ed25519` keys ([#31092](https://github.com/hashicorp/terraform/issues/31092))\r\n*
+        Crash with invalid module source ([#31060](https://github.com/hashicorp/terraform/issues/31060))\r\n*
+        Incorrect \"Module is incompatible with count, for_each, and depends_on\"
+        error when a provider is nested within a module along with a sub-module using
+        `count` or `for_each` ([#31091](https://github.com/hashicorp/terraform/issues/31091))"
+      created_at: "2022-05-23T21:29:44Z"
+      draft: false
+      html_url: https://github.com/hashicorp/terraform/releases/tag/v1.2.1
+      id: 67611650
+      name: v1.2.1
+      node_id: RE_kwDOAQ6CpM4EB6wC
+      prerelease: false
+      published_at: "2022-05-23T23:07:15Z"
+      reactions:
+        "+1": 7
+        "-1": 0
+        confused: 0
+        eyes: 0
+        heart: 0
+        hooray: 0
+        laugh: 0
+        rocket: 12
+        total_count: 19
+        url: https://api.github.com/repos/hashicorp/terraform/releases/67611650/reactions
+      tag_name: v1.2.1
+      tarball_url: https://api.github.com/repos/hashicorp/terraform/tarball/v1.2.1
+      target_commitish: main
+      upload_url: https://uploads.github.com/repos/hashicorp/terraform/releases/67611650/assets{?name,label}
+      url: https://api.github.com/repos/hashicorp/terraform/releases/67611650
+      zipball_url: https://api.github.com/repos/hashicorp/terraform/zipball/v1.2.1
+meta:
+  dependencies:
+    terraform:
+      1.2.1:
+        githubRelease:
+          assets: []
+          assets_url: https://api.github.com/repos/hashicorp/terraform/releases/67611650/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/82990137?v=4
+            events_url: https://api.github.com/users/hc-github-team-tf-core/events{/privacy}
+            followers_url: https://api.github.com/users/hc-github-team-tf-core/followers
+            following_url: https://api.github.com/users/hc-github-team-tf-core/following{/other_user}
+            gists_url: https://api.github.com/users/hc-github-team-tf-core/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/hc-github-team-tf-core
+            id: 82990137
+            login: hc-github-team-tf-core
+            node_id: MDQ6VXNlcjgyOTkwMTM3
+            organizations_url: https://api.github.com/users/hc-github-team-tf-core/orgs
+            received_events_url: https://api.github.com/users/hc-github-team-tf-core/received_events
+            repos_url: https://api.github.com/users/hc-github-team-tf-core/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/hc-github-team-tf-core/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/hc-github-team-tf-core/subscriptions
+            type: User
+            url: https://api.github.com/users/hc-github-team-tf-core
+          body: "## 1.2.1 (May 23, 2022)\r\n\r\nBUG FIXES:\r\n\r\n* SSH provisioner
+            connections fail when using signed `ed25519` keys ([#31092](https://github.com/hashicorp/terraform/issues/31092))\r\n*
+            Crash with invalid module source ([#31060](https://github.com/hashicorp/terraform/issues/31060))\r\n*
+            Incorrect \"Module is incompatible with count, for_each, and depends_on\"
+            error when a provider is nested within a module along with a sub-module
+            using `count` or `for_each` ([#31091](https://github.com/hashicorp/terraform/issues/31091))"
+          created_at: "2022-05-23T21:29:44Z"
+          draft: false
+          html_url: https://github.com/hashicorp/terraform/releases/tag/v1.2.1
+          id: 67611650
+          name: v1.2.1
+          node_id: RE_kwDOAQ6CpM4EB6wC
+          prerelease: false
+          published_at: "2022-05-23T23:07:15Z"
+          reactions:
+            "+1": 7
+            "-1": 0
+            confused: 0
+            eyes: 0
+            heart: 0
+            hooray: 0
+            laugh: 0
+            rocket: 12
+            total_count: 19
+            url: https://api.github.com/repos/hashicorp/terraform/releases/67611650/reactions
+          tag_name: v1.2.1
+          tarball_url: https://api.github.com/repos/hashicorp/terraform/tarball/v1.2.1
+          target_commitish: main
+          upload_url: https://uploads.github.com/repos/hashicorp/terraform/releases/67611650/assets{?name,label}
+          url: https://api.github.com/repos/hashicorp/terraform/releases/67611650
+          zipball_url: https://api.github.com/repos/hashicorp/terraform/zipball/v1.2.1

--- a/provider-terraform-controller/variant.mod
+++ b/provider-terraform-controller/variant.mod
@@ -1,0 +1,24 @@
+provisioners:
+  files:
+    Dockerfile:
+      source: Dockerfile.tpl
+      arguments:
+        provider_terraform_version: "{{ .provider_terraform.version }}"
+        terraform_version: "{{ .terraform.version }}"
+  textReplace:
+    goss/goss.yaml:
+      from: "Terraform v{{ .terraform.previousVersion }}"
+      to: "Terraform v{{ .terraform.version }}"
+
+dependencies:
+  provider_terraform:
+    releasesFrom:
+      dockerImageTags:
+        source: crossplane/provider-terraform-controller
+    version: "> 0.0.1"
+    validVersionPattern: "[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+"
+  terraform:
+    releasesFrom:
+      githubReleases:
+        source: hashicorp/terraform
+    version: "> 1.0.0"


### PR DESCRIPTION
https://github.com/crossplane-contrib/provider-terraform
https://hub.docker.com/r/crossplane/provider-terraform-controller

The version of terraform cli included in crossplane's provider-terraform-controller is v1.0.1 and older.
Therefore, prepare an image with the latest version.