### PR TITLE
add argocd-helmfile-plugin image

### DIFF
--- a/argocd-helmfile-plugin/Dockerfile
+++ b/argocd-helmfile-plugin/Dockerfile
@@ -1,0 +1,77 @@
+FROM ubuntu:22.04
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ARG KUBECTL_VERSION=1.24.8
+ARG HELMFILE_VERSION=0.148.1
+ARG HELM_VERSION=3.10.2
+ARG HELM_FILE_NAME=helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz
+ARG HELMFILE_FILE_NAME=helmfile_${HELMFILE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
+ARG KUSTOMIZE_VERSION=4.5.7
+ARG KUSTOMIZE_FILE_NAME=kustomize_v${KUSTOMIZE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
+ARG HELM_DIFF_VERSION=3.6.0
+ARG HELM_SECRETS_VERSION=4.2.2
+ARG HELM_GIT_VERSION=0.13.0
+ARG HELM_WORKING_DIR=/helm-working-dir
+
+LABEL version="${HELMFILE_VERSION}-${HELM_VERSION}"
+LABEL maintainer="sakamoto@chatwork.com"
+LABEL maintainer="ozaki@chatwork.com"
+
+WORKDIR /
+
+USER root
+ENV ARGOCD_USER_ID=999
+ENV ARGOCD_GROUP_ID=999
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -qq \
+    && apt install --no-install-recommends -y \
+      ca-certificates \
+      git bash curl jq wget openssh-client \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g $ARGOCD_GROUP_ID argocd \
+    && useradd -r -u $ARGOCD_USER_ID -g argocd argocd \
+    && mkdir -p /home/argocd \
+    && mkdir -p $HELM_WORKING_DIR \
+    && chown argocd:argocd /home/argocd \
+    && chown argocd:0 $HELM_WORKING_DIR \
+    && chmod g=u /home/argocd \
+    && chmod g=u $HELM_WORKING_DIR
+
+ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /tmp
+RUN mv /tmp/kubectl /usr/local/bin/kubectl \
+  && chmod 755 /usr/local/bin/kubectl
+
+ADD https://get.helm.sh/${HELM_FILE_NAME} /tmp
+RUN tar -zxvf /tmp/${HELM_FILE_NAME} -C /tmp \
+  && mv /tmp/${TARGETOS}-${TARGETARCH}/helm /usr/local/bin/helm \
+  && chmod 755 /usr/local/bin/helm \
+  && rm -rf /tmp/*
+
+ADD https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILE_NAME} /tmp
+RUN tar -zxf /tmp/${KUSTOMIZE_FILE_NAME} -C /tmp \
+    && mv /tmp/kustomize /usr/local/bin/kustomize \
+    && chmod 755 /usr/local/bin/kustomize \
+    && rm -fr /tmp/*
+
+ADD https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/${HELMFILE_FILE_NAME} /tmp
+
+RUN tar -zxvf /tmp/${HELMFILE_FILE_NAME} -C /tmp \
+  && mv /tmp/helmfile /usr/local/bin/helmfile \
+  && chmod 755 /usr/local/bin/helmfile \
+  && rm -rf /tmp/*
+
+ENV HELM_CACHE_HOME=$HELM_WORKING_DIR/.cache
+ENV HELM_CONFIG_HOME=$HELM_WORKING_DIR/.config
+ENV HELM_DATA_HOME=$HELM_WORKING_DIR/.local
+ENV USER=argocd
+USER $ARGOCD_USER_ID
+
+RUN helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} \
+    && helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION} \
+    && helm plugin install https://github.com/aslafy-z/helm-git.git --version v${HELM_GIT_VERSION}
+
+WORKDIR /home/argocd
+ENTRYPOINT ["/usr/local/bin/helmfile"]

--- a/argocd-helmfile-plugin/Dockerfile.arm64
+++ b/argocd-helmfile-plugin/Dockerfile.arm64
@@ -1,0 +1,56 @@
+FROM amazon/aws-cli:latest
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ARG KUBECTL_VERSION=1.23.7
+ARG HELMFILE_VERSION=0.148.1
+ARG HELM_VERSION=3.10.2
+ARG HELM_FILE_NAME=helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz
+ARG HELMFILE_FILE_NAME=helmfile_${HELMFILE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
+ARG KUSTOMIZE_VERSION=4.5.7
+ARG KUSTOMIZE_FILE_NAME=kustomize_v${KUSTOMIZE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
+ARG HELM_DIFF_VERSION=3.6.0
+ARG HELM_SECRETS_VERSION=4.1.1
+ARG HELM_GIT_VERSION=0.13.0
+
+LABEL version="${HELMFILE_VERSION}-${HELM_VERSION}"
+LABEL maintainer="sakamoto@chatwork.com"
+LABEL maintainer="ozaki@chatwork.com"
+
+WORKDIR /
+
+RUN yum update -y \
+    && yum upgrade -y \
+    && yum install jq bash tar gzip unzip git curl wget -y \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /tmp
+RUN mv /tmp/kubectl /usr/local/bin/kubectl \
+  && chmod 755 /usr/local/bin/kubectl
+
+ADD https://get.helm.sh/${HELM_FILE_NAME} /tmp
+RUN tar -zxvf /tmp/${HELM_FILE_NAME} -C /tmp \
+  && mv /tmp/${TARGETOS}-${TARGETARCH}/helm /usr/local/bin/helm \
+  && chmod 755 /usr/local/bin/helm \
+  && rm -rf /tmp/*
+
+ADD https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILE_NAME} /tmp
+RUN tar -zxf /tmp/${KUSTOMIZE_FILE_NAME} -C /tmp \
+    && mv /tmp/kustomize /usr/local/bin/kustomize \
+    && chmod 755 /usr/local/bin/kustomize \
+    && rm -fr /tmp/*
+
+ADD https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/${HELMFILE_FILE_NAME} /tmp
+
+RUN tar -zxvf /tmp/${HELMFILE_FILE_NAME} -C /tmp \
+  && mv /tmp/helmfile /usr/local/bin/helmfile \
+  && chmod 755 /usr/local/bin/helmfile \
+  && rm -rf /tmp/*
+
+RUN helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} \
+    && helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION} \
+    && helm plugin install https://github.com/aslafy-z/helm-git.git --version v${HELM_GIT_VERSION}
+
+ENTRYPOINT ["/usr/local/bin/helmfile"]

--- a/argocd-helmfile-plugin/Dockerfile.tpl
+++ b/argocd-helmfile-plugin/Dockerfile.tpl
@@ -1,0 +1,77 @@
+FROM ubuntu:22.04
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ARG KUBECTL_VERSION=1.24.8
+ARG HELMFILE_VERSION={{ .helmfile_version }}
+ARG HELM_VERSION={{ .helm_version }}
+ARG HELM_FILE_NAME=helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz
+ARG HELMFILE_FILE_NAME=helmfile_${HELMFILE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
+ARG KUSTOMIZE_VERSION=4.5.7
+ARG KUSTOMIZE_FILE_NAME=kustomize_v${KUSTOMIZE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
+ARG HELM_DIFF_VERSION=3.6.0
+ARG HELM_SECRETS_VERSION=4.2.2
+ARG HELM_GIT_VERSION=0.13.0
+ARG HELM_WORKING_DIR=/helm-working-dir
+
+LABEL version="${HELMFILE_VERSION}-${HELM_VERSION}"
+LABEL maintainer="sakamoto@chatwork.com"
+LABEL maintainer="ozaki@chatwork.com"
+
+WORKDIR /
+
+USER root
+ENV ARGOCD_USER_ID=999
+ENV ARGOCD_GROUP_ID=999
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update -qq \
+    && apt install --no-install-recommends -y \
+      ca-certificates \
+      git bash curl jq wget openssh-client \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g $ARGOCD_GROUP_ID argocd \
+    && useradd -r -u $ARGOCD_USER_ID -g argocd argocd \
+    && mkdir -p /home/argocd \
+    && mkdir -p $HELM_WORKING_DIR \
+    && chown argocd:argocd /home/argocd \
+    && chown argocd:0 $HELM_WORKING_DIR \
+    && chmod g=u /home/argocd \
+    && chmod g=u $HELM_WORKING_DIR
+
+ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /tmp
+RUN mv /tmp/kubectl /usr/local/bin/kubectl \
+  && chmod 755 /usr/local/bin/kubectl
+
+ADD https://get.helm.sh/${HELM_FILE_NAME} /tmp
+RUN tar -zxvf /tmp/${HELM_FILE_NAME} -C /tmp \
+  && mv /tmp/${TARGETOS}-${TARGETARCH}/helm /usr/local/bin/helm \
+  && chmod 755 /usr/local/bin/helm \
+  && rm -rf /tmp/*
+
+ADD https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILE_NAME} /tmp
+RUN tar -zxf /tmp/${KUSTOMIZE_FILE_NAME} -C /tmp \
+    && mv /tmp/kustomize /usr/local/bin/kustomize \
+    && chmod 755 /usr/local/bin/kustomize \
+    && rm -fr /tmp/*
+
+ADD https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/${HELMFILE_FILE_NAME} /tmp
+
+RUN tar -zxvf /tmp/${HELMFILE_FILE_NAME} -C /tmp \
+  && mv /tmp/helmfile /usr/local/bin/helmfile \
+  && chmod 755 /usr/local/bin/helmfile \
+  && rm -rf /tmp/*
+
+ENV HELM_CACHE_HOME=$HELM_WORKING_DIR/.cache
+ENV HELM_CONFIG_HOME=$HELM_WORKING_DIR/.config
+ENV HELM_DATA_HOME=$HELM_WORKING_DIR/.local
+ENV USER=argocd
+USER $ARGOCD_USER_ID
+
+RUN helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} \
+    && helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION} \
+    && helm plugin install https://github.com/aslafy-z/helm-git.git --version v${HELM_GIT_VERSION}
+
+WORKDIR /home/argocd
+ENTRYPOINT ["/usr/local/bin/helmfile"]

--- a/argocd-helmfile-plugin/Makefile
+++ b/argocd-helmfile-plugin/Makefile
@@ -1,0 +1,43 @@
+ARCH:=$(shell uname -m)
+TAG:=$(shell case "$(ARCH)" in \
+	("arm64"|"aarch64") echo "arm64" ;; \
+	("x86_64") echo "x86_64" ;; \
+	(*) echo $(ARCH) ;; \
+esac)
+PLATFORM:=$(shell case "$(ARCH)" in \
+	("arm64"|"aarch64") echo "arm64" ;; \
+	("x86_64") echo "amd64" ;; \
+	(*) echo $(ARCH) ;; \
+esac)
+
+.PHONY: build
+build:
+	@docker buildx build -t chatwork/`basename $$PWD`:latest --platform linux/${PLATFORM} -f Dockerfile --load .; \
+	version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+	if [ -n "$$version" ]; then \
+		docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+	fi
+
+.PHONY: check
+check:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
+		if [ -z "$$version" ]; then \
+			echo "\033[91mError: version is not defined in Dockerfile.\033[0m"; \
+			exit 1; \
+		fi;
+	@echo "\033[92mno problem.\033[0m";
+
+.PHONY: test
+test: build
+	docker-compose -f docker-compose.test.yml up --no-start sut
+	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
+	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
+
+.PHONY: push
+push:
+	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
+			echo "no changes"; \
+		else \
+			docker buildx build -t chatwork/`basename $$PWD`:$$version -t chatwork/`basename $$PWD`:latest --platform linux/amd64,linux/arm64 -f Dockerfile --push .; \
+		fi

--- a/argocd-helmfile-plugin/README.md
+++ b/argocd-helmfile-plugin/README.md
@@ -1,0 +1,102 @@
+# argocd-helmfile-plugin
+
+This image is to enable the use of helmfile in the sidecar for argocd plugin.
+
+- https://github.com/helmfile/helmfile
+- https://argo-cd.readthedocs.io/en/latest/user-guide/config-management-plugins/
+
+# helm version
+
+This image supports only helm3.
+
+## Usage
+
+You need configmap for cmp-plugin.
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: helmfile-plugin
+  namespace: argocd
+data:
+  plugin.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: helmfile-plugin
+    spec:
+      version: v1.0
+      generate:
+        args:
+          - helmfile -q template --include-crds --skip-tests
+        command:
+          - /bin/sh
+          - -c
+      discover:
+        find:
+          command:
+            - sh
+            - -c
+            - find . -name helmfile.yaml
+```
+
+and you need to add manifest sidecar in repo-server manifest.
+
+```
+    spec:
+      containers:
+      .
+      .
+      .
+      - name: helmfile-plugin
+        command:
+          - /var/run/argocd/argocd-cmp-server
+        image: chatwork/argocd-helmfile-sidecar-plugin:latest
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 999
+        volumeMounts:
+          - mountPath: /var/run/argocd
+            name: var-files
+          - mountPath: /home/argocd/cmp-server/plugins
+            name: plugins
+          - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+            name: helmfile-plugin
+            subPath: plugin.yaml
+          - mountPath: /tmp
+            name: helmfile-plugin-tmp
+      .
+      .
+      .
+      volumes:
+        - configMap:
+            name: helmfile-plugin
+          name: helmfile-plugin
+        - emptyDir: {}
+          name: helmfile-plugin-tmp
+      .
+      .
+      .
+      initContainers:
+      - command:
+        - cp
+        - -n
+        - /usr/local/bin/argocd
+        - /var/run/argocd/argocd-cmp-server
+        image: quay.io/argoproj/argocd:latest
+        imagePullPolicy: IfNotPresent
+        name: copyutil
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+```

--- a/argocd-helmfile-plugin/docker-compose.test.yml
+++ b/argocd-helmfile-plugin/docker-compose.test.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  argocd-helmfile-plugin:
+    build:
+      context: .
+    image: chatwork/argocd-helmfile-plugin
+  sut:
+    image: chatwork/dgoss:latest
+    environment:
+      GOSS_FILES_PATH: /goss
+      GOSS_FILES_STRATEGY: cp
+    entrypoint: ""
+    command: /usr/local/bin/dgoss run --entrypoint tail chatwork/argocd-helmfile-plugin -f /dev/null
+    container_name: argocd-helmfile-plugin
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - argocd-helmfile-plugin

--- a/argocd-helmfile-plugin/goss/goss.yaml
+++ b/argocd-helmfile-plugin/goss/goss.yaml
@@ -1,0 +1,27 @@
+file:
+  /usr/local/bin/helmfile:
+    exists: true
+    mode: "0755"
+  /usr/local/bin/helm:
+    exists: true
+    mode: "0755"
+  /usr/local/bin/kubectl:
+    exists: true
+    mode: "0755"
+command:
+  /usr/local/bin/helm version:
+    exit-status: 0
+    stdout:
+      - 3.10.2
+  /usr/local/bin/helmfile -v:
+    exit-status: 0
+    stdout:
+      - 0.148.1
+  /usr/local/bin/helm plugin list:
+    exit-status: 0
+    stdout:
+      - /^diff/
+      - /^helm-git/
+      - /^secrets/
+  /usr/local/bin/kubectl version --client:
+    exit-status: 0

--- a/argocd-helmfile-plugin/goss/goss.yaml.tpl
+++ b/argocd-helmfile-plugin/goss/goss.yaml.tpl
@@ -1,0 +1,27 @@
+file:
+  /usr/local/bin/helmfile:
+    exists: true
+    mode: "0755"
+  /usr/local/bin/helm:
+    exists: true
+    mode: "0755"
+  /usr/local/bin/kubectl:
+    exists: true
+    mode: "0755"
+command:
+  /usr/local/bin/helm version:
+    exit-status: 0
+    stdout:
+      - {{ .helm_version }}
+  /usr/local/bin/helmfile -v:
+    exit-status: 0
+    stdout:
+      - {{ .helmfile_version }}
+  /usr/local/bin/helm plugin list:
+    exit-status: 0
+    stdout:
+      - /^diff/
+      - /^helm-git/
+      - /^secrets/
+  /usr/local/bin/kubectl version --client:
+    exit-status: 0

--- a/argocd-helmfile-plugin/hooks/test
+++ b/argocd-helmfile-plugin/hooks/test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make test

--- a/argocd-helmfile-plugin/variant.lock
+++ b/argocd-helmfile-plugin/variant.lock
@@ -1,0 +1,6664 @@
+dependencies:
+  helm:
+    version: 3.10.2
+    previousVersion: 3.10.1
+    versions:
+    - 3.9.2
+    - 3.9.3
+    - 3.9.4
+    - 3.10.0
+    - 3.10.1
+    - 3.10.2
+    githubRelease:
+      assets:
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-amd64.tar.gz.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:16Z"
+        download_count: 22
+        id: 84166626
+        label: null
+        name: helm-v3.10.2-darwin-amd64.tar.gz.asc
+        node_id: RA_kwDOApspmc4FBEfi
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:17Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166626
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-amd64.tar.gz.sha256.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:17Z"
+        download_count: 13
+        id: 84166628
+        label: null
+        name: helm-v3.10.2-darwin-amd64.tar.gz.sha256.asc
+        node_id: RA_kwDOApspmc4FBEfk
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:17Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166628
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-amd64.tar.gz.sha256sum.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:17Z"
+        download_count: 13
+        id: 84166629
+        label: null
+        name: helm-v3.10.2-darwin-amd64.tar.gz.sha256sum.asc
+        node_id: RA_kwDOApspmc4FBEfl
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:18Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166629
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-arm64.tar.gz.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:18Z"
+        download_count: 14
+        id: 84166630
+        label: null
+        name: helm-v3.10.2-darwin-arm64.tar.gz.asc
+        node_id: RA_kwDOApspmc4FBEfm
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:18Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166630
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-arm64.tar.gz.sha256.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:18Z"
+        download_count: 12
+        id: 84166632
+        label: null
+        name: helm-v3.10.2-darwin-arm64.tar.gz.sha256.asc
+        node_id: RA_kwDOApspmc4FBEfo
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:18Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166632
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-arm64.tar.gz.sha256sum.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:18Z"
+        download_count: 12
+        id: 84166633
+        label: null
+        name: helm-v3.10.2-darwin-arm64.tar.gz.sha256sum.asc
+        node_id: RA_kwDOApspmc4FBEfp
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:19Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166633
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-386.tar.gz.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:19Z"
+        download_count: 19
+        id: 84166635
+        label: null
+        name: helm-v3.10.2-linux-386.tar.gz.asc
+        node_id: RA_kwDOApspmc4FBEfr
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:19Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166635
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-386.tar.gz.sha256.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:19Z"
+        download_count: 14
+        id: 84166636
+        label: null
+        name: helm-v3.10.2-linux-386.tar.gz.sha256.asc
+        node_id: RA_kwDOApspmc4FBEfs
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:20Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166636
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-386.tar.gz.sha256sum.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:20Z"
+        download_count: 15
+        id: 84166637
+        label: null
+        name: helm-v3.10.2-linux-386.tar.gz.sha256sum.asc
+        node_id: RA_kwDOApspmc4FBEft
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:20Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166637
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-amd64.tar.gz.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:20Z"
+        download_count: 392
+        id: 84166639
+        label: null
+        name: helm-v3.10.2-linux-amd64.tar.gz.asc
+        node_id: RA_kwDOApspmc4FBEfv
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:21Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166639
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-amd64.tar.gz.sha256.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:21Z"
+        download_count: 344
+        id: 84166640
+        label: null
+        name: helm-v3.10.2-linux-amd64.tar.gz.sha256.asc
+        node_id: RA_kwDOApspmc4FBEfw
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:21Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166640
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-amd64.tar.gz.sha256sum.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:21Z"
+        download_count: 17
+        id: 84166641
+        label: null
+        name: helm-v3.10.2-linux-amd64.tar.gz.sha256sum.asc
+        node_id: RA_kwDOApspmc4FBEfx
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:22Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166641
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm.tar.gz.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:22Z"
+        download_count: 13
+        id: 84166644
+        label: null
+        name: helm-v3.10.2-linux-arm.tar.gz.asc
+        node_id: RA_kwDOApspmc4FBEf0
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:22Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166644
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm.tar.gz.sha256.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:22Z"
+        download_count: 11
+        id: 84166645
+        label: null
+        name: helm-v3.10.2-linux-arm.tar.gz.sha256.asc
+        node_id: RA_kwDOApspmc4FBEf1
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:22Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166645
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm.tar.gz.sha256sum.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:22Z"
+        download_count: 11
+        id: 84166646
+        label: null
+        name: helm-v3.10.2-linux-arm.tar.gz.sha256sum.asc
+        node_id: RA_kwDOApspmc4FBEf2
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:23Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166646
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm64.tar.gz.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:23Z"
+        download_count: 104
+        id: 84166648
+        label: null
+        name: helm-v3.10.2-linux-arm64.tar.gz.asc
+        node_id: RA_kwDOApspmc4FBEf4
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:23Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166648
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm64.tar.gz.sha256.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:23Z"
+        download_count: 101
+        id: 84166649
+        label: null
+        name: helm-v3.10.2-linux-arm64.tar.gz.sha256.asc
+        node_id: RA_kwDOApspmc4FBEf5
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:24Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166649
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm64.tar.gz.sha256sum.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:24Z"
+        download_count: 11
+        id: 84166651
+        label: null
+        name: helm-v3.10.2-linux-arm64.tar.gz.sha256sum.asc
+        node_id: RA_kwDOApspmc4FBEf7
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:24Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166651
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-ppc64le.tar.gz.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:24Z"
+        download_count: 11
+        id: 84166654
+        label: null
+        name: helm-v3.10.2-linux-ppc64le.tar.gz.asc
+        node_id: RA_kwDOApspmc4FBEf-
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:25Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166654
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-ppc64le.tar.gz.sha256.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:25Z"
+        download_count: 10
+        id: 84166656
+        label: null
+        name: helm-v3.10.2-linux-ppc64le.tar.gz.sha256.asc
+        node_id: RA_kwDOApspmc4FBEgA
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:25Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166656
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-ppc64le.tar.gz.sha256sum.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:25Z"
+        download_count: 10
+        id: 84166658
+        label: null
+        name: helm-v3.10.2-linux-ppc64le.tar.gz.sha256sum.asc
+        node_id: RA_kwDOApspmc4FBEgC
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:26Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166658
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-s390x.tar.gz.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:26Z"
+        download_count: 11
+        id: 84166659
+        label: null
+        name: helm-v3.10.2-linux-s390x.tar.gz.asc
+        node_id: RA_kwDOApspmc4FBEgD
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:26Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166659
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-s390x.tar.gz.sha256.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:26Z"
+        download_count: 10
+        id: 84166662
+        label: null
+        name: helm-v3.10.2-linux-s390x.tar.gz.sha256.asc
+        node_id: RA_kwDOApspmc4FBEgG
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:26Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166662
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-s390x.tar.gz.sha256sum.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:26Z"
+        download_count: 10
+        id: 84166663
+        label: null
+        name: helm-v3.10.2-linux-s390x.tar.gz.sha256sum.asc
+        node_id: RA_kwDOApspmc4FBEgH
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:27Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166663
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-windows-amd64.zip.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:27Z"
+        download_count: 27
+        id: 84166666
+        label: null
+        name: helm-v3.10.2-windows-amd64.zip.asc
+        node_id: RA_kwDOApspmc4FBEgK
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:27Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166666
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-windows-amd64.zip.sha256.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:27Z"
+        download_count: 13
+        id: 84166668
+        label: null
+        name: helm-v3.10.2-windows-amd64.zip.sha256.asc
+        node_id: RA_kwDOApspmc4FBEgM
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:28Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166668
+      - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-windows-amd64.zip.sha256sum.asc
+        content_type: application/octet-stream
+        created_at: "2022-11-10T17:12:28Z"
+        download_count: 13
+        id: 84166670
+        label: null
+        name: helm-v3.10.2-windows-amd64.zip.sha256sum.asc
+        node_id: RA_kwDOApspmc4FBEgO
+        size: 833
+        state: uploaded
+        updated_at: "2022-11-10T17:12:28Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+          events_url: https://api.github.com/users/mattfarina/events{/privacy}
+          followers_url: https://api.github.com/users/mattfarina/followers
+          following_url: https://api.github.com/users/mattfarina/following{/other_user}
+          gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/mattfarina
+          id: 62991
+          login: mattfarina
+          node_id: MDQ6VXNlcjYyOTkx
+          organizations_url: https://api.github.com/users/mattfarina/orgs
+          received_events_url: https://api.github.com/users/mattfarina/received_events
+          repos_url: https://api.github.com/users/mattfarina/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+          type: User
+          url: https://api.github.com/users/mattfarina
+        url: https://api.github.com/repos/helm/helm/releases/assets/84166670
+      assets_url: https://api.github.com/repos/helm/helm/releases/82711070/assets
+      author:
+        avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+        events_url: https://api.github.com/users/mattfarina/events{/privacy}
+        followers_url: https://api.github.com/users/mattfarina/followers
+        following_url: https://api.github.com/users/mattfarina/following{/other_user}
+        gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+        gravatar_id: ""
+        html_url: https://github.com/mattfarina
+        id: 62991
+        login: mattfarina
+        node_id: MDQ6VXNlcjYyOTkx
+        organizations_url: https://api.github.com/users/mattfarina/orgs
+        received_events_url: https://api.github.com/users/mattfarina/received_events
+        repos_url: https://api.github.com/users/mattfarina/repos
+        site_admin: false
+        starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+        type: User
+        url: https://api.github.com/users/mattfarina
+      body: "Helm v3.10.2 is a patch release. Users are encouraged to upgrade for
+        the best experience. Users are encouraged to upgrade for the best experience.\r\n\r\nThe
+        community keeps growing, and we'd love to see you there!\r\n\r\n- Join the
+        discussion in [Kubernetes Slack](https://kubernetes.slack.com):\r\n  -  for
+        questions and just to hang out\r\n  -  for discussing PRs, code, and bugs\r\n-
+        Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)\r\n-
+        Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)\r\n\r\n##
+        Installation and Upgrading\r\n\r\nDownload Helm v3.10.2. The common platform
+        binaries are here:\r\n\r\n- [MacOS amd64](https://get.helm.sh/helm-v3.10.2-darwin-amd64.tar.gz)
+        ([checksum](https://get.helm.sh/helm-v3.10.2-darwin-amd64.tar.gz.sha256sum)
+        / e889960e4c1d7e2dfdb91b102becfaf22700cb86dc3e3553d9bebd7bab5a3803)\r\n- [MacOS
+        arm64](https://get.helm.sh/helm-v3.10.2-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-darwin-arm64.tar.gz.sha256sum)
+        / 460441eea1764ca438e29fa0e38aa0d2607402f753cb656a4ab0da9223eda494)\r\n- [Linux
+        amd64](https://get.helm.sh/helm-v3.10.2-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-amd64.tar.gz.sha256sum)
+        / 2315941a13291c277dac9f65e75ead56386440d3907e0540bf157ae70f188347)\r\n- [Linux
+        arm](https://get.helm.sh/helm-v3.10.2-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-arm.tar.gz.sha256sum)
+        / 25af344f46348958baa1c758cdf3b204ede3ddc483be1171ed3738d47efd0aae)\r\n- [Linux
+        arm64](https://get.helm.sh/helm-v3.10.2-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-arm64.tar.gz.sha256sum)
+        / 57fa17b6bb040a3788116557a72579f2180ea9620b4ee8a9b7244e5901df02e4)\r\n- [Linux
+        i386](https://get.helm.sh/helm-v3.10.2-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-386.tar.gz.sha256sum)
+        / ac9cbef2ec1237e2723ee8d3a92d1c4525a2da7cecc11336ba67de9bb6b473f0)\r\n- [Linux
+        ppc64le](https://get.helm.sh/helm-v3.10.2-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-ppc64le.tar.gz.sha256sum)
+        / 53a578b84155d31c3e62dd93a88586b75e876dae82c7912c895ee5a574fa6209)\r\n- [Linux
+        s390x](https://get.helm.sh/helm-v3.10.2-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-s390x.tar.gz.sha256sum)
+        / 33cb4a3382bea6bcd7eb7f385dd08941bdc84d0020345951eb467fbc8f5ccb60)\r\n- [Windows
+        amd64](https://get.helm.sh/helm-v3.10.2-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.10.2-windows-amd64.zip.sha256sum)
+        / f1a3190adecc26270bbef4f3ab2d1a56509f9d8df95413cdd6e3151f6f367862)\r\n\r\nThis
+        release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E
+        ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina).
+        Please use the attached signatures for verifying this release using `gpg`.\r\n\r\nThe
+        [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going
+        from there. For **upgrade instructions** or detailed installation notes, check
+        the [install guide](https://helm.sh/docs/intro/install/). You can also use
+        a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
+        on any system with `bash`.\r\n\r\n## What's Next\r\n\r\n- 3.10.3 will contain
+        only bug fixes and be released on December 14, 2022\r\n- 3.11.0 is the next
+        feature releaseand be released on January 18, 2023\r\n\r\n## Changelog\r\n\r\n-
+        fix a few function names on comments 50f003e5ee8704ec937a756c646870227d7c8b58
+        (cui fliter)\r\n- redirect registry client output to stderr c3a62f7880be8bdc904f2d54c4b0c16a86ec204c
+        (Cyril Jouve)\r\n- Readiness & liveness probes correct port 727bdf1813df73073d5a8eba4581201ef6518f93
+        (Peter Leong)"
+      created_at: "2022-11-10T14:53:00Z"
+      draft: false
+      html_url: https://github.com/helm/helm/releases/tag/v3.10.2
+      id: 82711070
+      mentions_count: 1
+      name: Helm v3.10.2
+      node_id: RE_kwDOApspmc4E7hIe
+      prerelease: false
+      published_at: "2022-11-10T17:13:10Z"
+      reactions:
+        "+1": 2
+        "-1": 0
+        confused: 0
+        eyes: 0
+        heart: 0
+        hooray: 0
+        laugh: 0
+        rocket: 2
+        total_count: 4
+        url: https://api.github.com/repos/helm/helm/releases/82711070/reactions
+      tag_name: v3.10.2
+      tarball_url: https://api.github.com/repos/helm/helm/tarball/v3.10.2
+      target_commitish: release-3.10
+      upload_url: https://uploads.github.com/repos/helm/helm/releases/82711070/assets{?name,label}
+      url: https://api.github.com/repos/helm/helm/releases/82711070
+      zipball_url: https://api.github.com/repos/helm/helm/zipball/v3.10.2
+  helmfile:
+    version: 0.148.1
+    previousVersion: 0.148.0
+    versions:
+    - 0.144.0
+    - 0.145.2
+    - 0.145.3
+    - "0145.4"
+    githubRelease:
+      assets:
+      - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.148.1/helmfile_0.148.1_checksums.txt
+        content_type: text/plain; charset=utf-8
+        created_at: "2022-11-13T08:28:13Z"
+        download_count: 8
+        id: 84435804
+        label: ""
+        name: helmfile_0.148.1_checksums.txt
+        node_id: RA_kwDOHEifes4FCGNc
+        size: 820
+        state: uploaded
+        updated_at: "2022-11-13T08:28:14Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+        url: https://api.github.com/repos/helmfile/helmfile/releases/assets/84435804
+      - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.148.1/helmfile_0.148.1_darwin_amd64.tar.gz
+        content_type: application/gzip
+        created_at: "2022-11-13T08:28:11Z"
+        download_count: 1
+        id: 84435800
+        label: ""
+        name: helmfile_0.148.1_darwin_amd64.tar.gz
+        node_id: RA_kwDOHEifes4FCGNY
+        size: 18117786
+        state: uploaded
+        updated_at: "2022-11-13T08:28:12Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+        url: https://api.github.com/repos/helmfile/helmfile/releases/assets/84435800
+      - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.148.1/helmfile_0.148.1_darwin_arm64.tar.gz
+        content_type: application/gzip
+        created_at: "2022-11-13T08:28:11Z"
+        download_count: 1
+        id: 84435799
+        label: ""
+        name: helmfile_0.148.1_darwin_arm64.tar.gz
+        node_id: RA_kwDOHEifes4FCGNX
+        size: 17301571
+        state: uploaded
+        updated_at: "2022-11-13T08:28:12Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+        url: https://api.github.com/repos/helmfile/helmfile/releases/assets/84435799
+      - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.148.1/helmfile_0.148.1_linux_386.tar.gz
+        content_type: application/gzip
+        created_at: "2022-11-13T08:28:09Z"
+        download_count: 0
+        id: 84435790
+        label: ""
+        name: helmfile_0.148.1_linux_386.tar.gz
+        node_id: RA_kwDOHEifes4FCGNO
+        size: 16226287
+        state: uploaded
+        updated_at: "2022-11-13T08:28:10Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+        url: https://api.github.com/repos/helmfile/helmfile/releases/assets/84435790
+      - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.148.1/helmfile_0.148.1_linux_amd64.tar.gz
+        content_type: application/gzip
+        created_at: "2022-11-13T08:28:12Z"
+        download_count: 18
+        id: 84435802
+        label: ""
+        name: helmfile_0.148.1_linux_amd64.tar.gz
+        node_id: RA_kwDOHEifes4FCGNa
+        size: 17281921
+        state: uploaded
+        updated_at: "2022-11-13T08:28:13Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+        url: https://api.github.com/repos/helmfile/helmfile/releases/assets/84435802
+      - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.148.1/helmfile_0.148.1_linux_arm64.tar.gz
+        content_type: application/gzip
+        created_at: "2022-11-13T08:28:12Z"
+        download_count: 9
+        id: 84435803
+        label: ""
+        name: helmfile_0.148.1_linux_arm64.tar.gz
+        node_id: RA_kwDOHEifes4FCGNb
+        size: 15611905
+        state: uploaded
+        updated_at: "2022-11-13T08:28:13Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+        url: https://api.github.com/repos/helmfile/helmfile/releases/assets/84435803
+      - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.148.1/helmfile_0.148.1_windows_386.tar.gz
+        content_type: application/gzip
+        created_at: "2022-11-13T08:28:10Z"
+        download_count: 1
+        id: 84435792
+        label: ""
+        name: helmfile_0.148.1_windows_386.tar.gz
+        node_id: RA_kwDOHEifes4FCGNQ
+        size: 17033169
+        state: uploaded
+        updated_at: "2022-11-13T08:28:11Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+        url: https://api.github.com/repos/helmfile/helmfile/releases/assets/84435792
+      - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.148.1/helmfile_0.148.1_windows_amd64.tar.gz
+        content_type: application/gzip
+        created_at: "2022-11-13T08:28:09Z"
+        download_count: 2
+        id: 84435789
+        label: ""
+        name: helmfile_0.148.1_windows_amd64.tar.gz
+        node_id: RA_kwDOHEifes4FCGNN
+        size: 17465333
+        state: uploaded
+        updated_at: "2022-11-13T08:28:10Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+        url: https://api.github.com/repos/helmfile/helmfile/releases/assets/84435789
+      - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.148.1/helmfile_0.148.1_windows_arm64.tar.gz
+        content_type: application/gzip
+        created_at: "2022-11-13T08:28:10Z"
+        download_count: 1
+        id: 84435791
+        label: ""
+        name: helmfile_0.148.1_windows_arm64.tar.gz
+        node_id: RA_kwDOHEifes4FCGNP
+        size: 15781009
+        state: uploaded
+        updated_at: "2022-11-13T08:28:11Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+        url: https://api.github.com/repos/helmfile/helmfile/releases/assets/84435791
+      assets_url: https://api.github.com/repos/helmfile/helmfile/releases/82901849/assets
+      author:
+        avatar_url: https://avatars.githubusercontent.com/u/22009?v=4
+        events_url: https://api.github.com/users/mumoshu/events{/privacy}
+        followers_url: https://api.github.com/users/mumoshu/followers
+        following_url: https://api.github.com/users/mumoshu/following{/other_user}
+        gists_url: https://api.github.com/users/mumoshu/gists{/gist_id}
+        gravatar_id: ""
+        html_url: https://github.com/mumoshu
+        id: 22009
+        login: mumoshu
+        node_id: MDQ6VXNlcjIyMDA5
+        organizations_url: https://api.github.com/users/mumoshu/orgs
+        received_events_url: https://api.github.com/users/mumoshu/received_events
+        repos_url: https://api.github.com/users/mumoshu/repos
+        site_admin: false
+        starred_url: https://api.github.com/users/mumoshu/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/mumoshu/subscriptions
+        type: User
+        url: https://api.github.com/users/mumoshu
+      body: "## What's Changed\r\n* Introduce a new test helper for easier log snapshot
+        testing by @mumoshu in https://github.com/helmfile/helmfile/pull/514\r\n*
+        fix: helmfile template fails when selector matches a chart fetched with go-getter
+        by @yxxhero in https://github.com/helmfile/helmfile/pull/499\r\n\r\n\r\n**Full
+        Changelog**: https://github.com/helmfile/helmfile/compare/v0.148.0...v0.148.1"
+      created_at: "2022-11-13T07:27:50Z"
+      draft: false
+      html_url: https://github.com/helmfile/helmfile/releases/tag/v0.148.1
+      id: 82901849
+      mentions_count: 2
+      name: v0.148.1
+      node_id: RE_kwDOHEifes4E8PtZ
+      prerelease: false
+      published_at: "2022-11-13T08:14:22Z"
+      tag_name: v0.148.1
+      tarball_url: https://api.github.com/repos/helmfile/helmfile/tarball/v0.148.1
+      target_commitish: main
+      upload_url: https://uploads.github.com/repos/helmfile/helmfile/releases/82901849/assets{?name,label}
+      url: https://api.github.com/repos/helmfile/helmfile/releases/82901849
+      zipball_url: https://api.github.com/repos/helmfile/helmfile/zipball/v0.148.1
+meta:
+  dependencies:
+    helm:
+      3.9.3:
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-darwin-amd64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:04Z"
+            download_count: 3
+            id: 74312380
+            label: null
+            name: helm-v3.9.3-darwin-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ebeq8
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:05Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312380
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-darwin-amd64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:05Z"
+            download_count: 3
+            id: 74312381
+            label: null
+            name: helm-v3.9.3-darwin-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ebeq9
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:05Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312381
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-darwin-amd64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:05Z"
+            download_count: 3
+            id: 74312382
+            label: null
+            name: helm-v3.9.3-darwin-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ebeq-
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:05Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312382
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-darwin-arm64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:05Z"
+            download_count: 3
+            id: 74312383
+            label: null
+            name: helm-v3.9.3-darwin-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ebeq_
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:06Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312383
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-darwin-arm64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:06Z"
+            download_count: 3
+            id: 74312386
+            label: null
+            name: helm-v3.9.3-darwin-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4EberC
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:06Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312386
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-darwin-arm64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:06Z"
+            download_count: 3
+            id: 74312393
+            label: null
+            name: helm-v3.9.3-darwin-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4EberJ
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:06Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312393
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-386.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:06Z"
+            download_count: 3
+            id: 74312394
+            label: null
+            name: helm-v3.9.3-linux-386.tar.gz.asc
+            node_id: RA_kwDOApspmc4EberK
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:06Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312394
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-386.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:06Z"
+            download_count: 3
+            id: 74312395
+            label: null
+            name: helm-v3.9.3-linux-386.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4EberL
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:07Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312395
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-386.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:07Z"
+            download_count: 3
+            id: 74312396
+            label: null
+            name: helm-v3.9.3-linux-386.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4EberM
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:07Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312396
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-amd64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:07Z"
+            download_count: 39
+            id: 74312397
+            label: null
+            name: helm-v3.9.3-linux-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4EberN
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:07Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312397
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-amd64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:07Z"
+            download_count: 35
+            id: 74312399
+            label: null
+            name: helm-v3.9.3-linux-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4EberP
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:08Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312399
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-amd64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:08Z"
+            download_count: 3
+            id: 74312400
+            label: null
+            name: helm-v3.9.3-linux-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4EberQ
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:08Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312400
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-arm.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:08Z"
+            download_count: 5
+            id: 74312401
+            label: null
+            name: helm-v3.9.3-linux-arm.tar.gz.asc
+            node_id: RA_kwDOApspmc4EberR
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:08Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312401
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-arm.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:08Z"
+            download_count: 3
+            id: 74312402
+            label: null
+            name: helm-v3.9.3-linux-arm.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4EberS
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:08Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312402
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-arm.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:08Z"
+            download_count: 3
+            id: 74312403
+            label: null
+            name: helm-v3.9.3-linux-arm.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4EberT
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312403
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-arm64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:09Z"
+            download_count: 7
+            id: 74312405
+            label: null
+            name: helm-v3.9.3-linux-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4EberV
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312405
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-arm64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:09Z"
+            download_count: 7
+            id: 74312406
+            label: null
+            name: helm-v3.9.3-linux-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4EberW
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312406
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-arm64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:09Z"
+            download_count: 3
+            id: 74312407
+            label: null
+            name: helm-v3.9.3-linux-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4EberX
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312407
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-ppc64le.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:09Z"
+            download_count: 2
+            id: 74312409
+            label: null
+            name: helm-v3.9.3-linux-ppc64le.tar.gz.asc
+            node_id: RA_kwDOApspmc4EberZ
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312409
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-ppc64le.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:09Z"
+            download_count: 2
+            id: 74312410
+            label: null
+            name: helm-v3.9.3-linux-ppc64le.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ebera
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:10Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312410
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-ppc64le.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:10Z"
+            download_count: 2
+            id: 74312412
+            label: null
+            name: helm-v3.9.3-linux-ppc64le.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eberc
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:10Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312412
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-s390x.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:10Z"
+            download_count: 2
+            id: 74312418
+            label: null
+            name: helm-v3.9.3-linux-s390x.tar.gz.asc
+            node_id: RA_kwDOApspmc4Eberi
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:10Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312418
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-s390x.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:10Z"
+            download_count: 2
+            id: 74312420
+            label: null
+            name: helm-v3.9.3-linux-s390x.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Eberk
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:10Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312420
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-linux-s390x.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:10Z"
+            download_count: 2
+            id: 74312422
+            label: null
+            name: helm-v3.9.3-linux-s390x.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eberm
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312422
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-windows-amd64.zip.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:11Z"
+            download_count: 5
+            id: 74312423
+            label: null
+            name: helm-v3.9.3-windows-amd64.zip.asc
+            node_id: RA_kwDOApspmc4Ebern
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312423
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-windows-amd64.zip.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:11Z"
+            download_count: 3
+            id: 74312428
+            label: null
+            name: helm-v3.9.3-windows-amd64.zip.sha256.asc
+            node_id: RA_kwDOApspmc4Ebers
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312428
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.3/helm-v3.9.3-windows-amd64.zip.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-10T18:22:11Z"
+            download_count: 3
+            id: 74312430
+            label: null
+            name: helm-v3.9.3-windows-amd64.zip.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eberu
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-10T18:22:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/74312430
+          assets_url: https://api.github.com/repos/helm/helm/releases/74131051/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+            events_url: https://api.github.com/users/mattfarina/events{/privacy}
+            followers_url: https://api.github.com/users/mattfarina/followers
+            following_url: https://api.github.com/users/mattfarina/following{/other_user}
+            gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/mattfarina
+            id: 62991
+            login: mattfarina
+            node_id: MDQ6VXNlcjYyOTkx
+            organizations_url: https://api.github.com/users/mattfarina/orgs
+            received_events_url: https://api.github.com/users/mattfarina/received_events
+            repos_url: https://api.github.com/users/mattfarina/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+            type: User
+            url: https://api.github.com/users/mattfarina
+          body: "Helm v3.9.3 is a patch release. Users are encouraged to upgrade for
+            the best experience. Users are encouraged to upgrade for the best experience.\r\n\r\nThe
+            community keeps growing, and we'd love to see you there!\r\n\r\n- Join
+            the discussion in [Kubernetes Slack](https://kubernetes.slack.com):\r\n
+            \ -  for questions and just to hang out\r\n  -  for discussing PRs, code,
+            and bugs\r\n- Hang out at the Public Developer Call: Thursday, 9:30 Pacific
+            via [Zoom](https://zoom.us/j/696660622)\r\n- Test, debug, and contribute
+            charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)\r\n\r\n##
+            Installation and Upgrading\r\n\r\nDownload Helm v3.9.3. The common platform
+            binaries are here:\r\n\r\n- [MacOS amd64](https://get.helm.sh/helm-v3.9.3-darwin-amd64.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.9.3-darwin-amd64.tar.gz.sha256sum)
+            / ca3d57bb68135fa45a7acc2612d472e8ad01b78f49eaca57490aefef74a61c95)\r\n-
+            [MacOS arm64](https://get.helm.sh/helm-v3.9.3-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.3-darwin-arm64.tar.gz.sha256sum)
+            / db20ee8758616e1d69e90aedc5eb940751888bdd2b031badf2080a05df4c9eb7)\r\n-
+            [Linux amd64](https://get.helm.sh/helm-v3.9.3-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.3-linux-amd64.tar.gz.sha256sum)
+            / 2d07360a9d93b18488f1ddb9de818b92ba738acbec6e1c66885a88703fa7b21c)\r\n-
+            [Linux arm](https://get.helm.sh/helm-v3.9.3-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.3-linux-arm.tar.gz.sha256sum)
+            / 2b8cdb8064914ed1f1cd17f8366e68eab2f14e9fb0b2a0bac0f47fac7fbddf36)\r\n-
+            [Linux arm64](https://get.helm.sh/helm-v3.9.3-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.3-linux-arm64.tar.gz.sha256sum)
+            / 59168c08c32293759005d0c509ce4be9038d7663827e05564c779e59658d8299)\r\n-
+            [Linux i386](https://get.helm.sh/helm-v3.9.3-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.3-linux-386.tar.gz.sha256sum)
+            / 634a5dca59674cb77fb7a69d08cee00c9051505e81af1c1d3ea96e5f3de84dbc)\r\n-
+            [Linux ppc64le](https://get.helm.sh/helm-v3.9.3-linux-ppc64le.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.9.3-linux-ppc64le.tar.gz.sha256sum)
+            / bf06f00a01e01a3ad011c0b70fbbb07db3e65f2134ed5e640a2a2832a4101f48)\r\n-
+            [Linux s390x](https://get.helm.sh/helm-v3.9.3-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.3-linux-s390x.tar.gz.sha256sum)
+            / 257a7373b380dc1fdb811030867c1483c511a5521bb1348fe59e97883582f9f3)\r\n-
+            [Windows amd64](https://get.helm.sh/helm-v3.9.3-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.9.3-windows-amd64.zip.sha256sum)
+            / cdd24727d233e620ce6e8ec21646a6218bde94cf3d5f24e9c4ae6a114939975d)\r\n\r\nThis
+            release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36
+            B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina).
+            Please use the attached signatures for verifying this release using `gpg`.\r\n\r\nThe
+            [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you
+            going from there. For **upgrade instructions** or detailed installation
+            notes, check the [install guide](https://helm.sh/docs/intro/install/).
+            You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
+            on any system with `bash`.\r\n\r\n## What's Next\r\n\r\n- 3.10.0 is the
+            next feature release and will be on September 13, 2022\r\n\r\n## Changelog\r\n\r\n-
+            Bump k8s.io/kube-openapi to fix CVE-2022-1996 in github.com/emicklei/go-restful
+            414ff28d4029ae8c8b05d62aa06c7fe3dee2bc58 (Guilherme Macedo)\r\n- fixes
+            #11142 missing array length check on release c801d8876a6fc9c9a5bfa15f31892e16cd30c7bd
+            (Arvid E. Picciani)\r\n"
+          created_at: "2022-08-10T17:34:56Z"
+          draft: false
+          html_url: https://github.com/helm/helm/releases/tag/v3.9.3
+          id: 74131051
+          mentions_count: 1
+          name: Helm 3.9.3
+          node_id: RE_kwDOApspmc4EayZr
+          prerelease: false
+          published_at: "2022-08-10T18:22:55Z"
+          reactions:
+            "+1": 3
+            "-1": 0
+            confused: 0
+            eyes: 0
+            heart: 0
+            hooray: 1
+            laugh: 0
+            rocket: 1
+            total_count: 5
+            url: https://api.github.com/repos/helm/helm/releases/74131051/reactions
+          tag_name: v3.9.3
+          tarball_url: https://api.github.com/repos/helm/helm/tarball/v3.9.3
+          target_commitish: release-3.9
+          upload_url: https://uploads.github.com/repos/helm/helm/releases/74131051/assets{?name,label}
+          url: https://api.github.com/repos/helm/helm/releases/74131051
+          zipball_url: https://api.github.com/repos/helm/helm/zipball/v3.9.3
+      3.9.4:
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-darwin-amd64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:59Z"
+            download_count: 3
+            id: 75744044
+            label: null
+            name: helm-v3.9.4-darwin-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Eg8Ms
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:29:00Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744044
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-darwin-amd64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:59Z"
+            download_count: 3
+            id: 75744043
+            label: null
+            name: helm-v3.9.4-darwin-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Eg8Mr
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:59Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744043
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-darwin-amd64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:59Z"
+            download_count: 3
+            id: 75744042
+            label: null
+            name: helm-v3.9.4-darwin-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eg8Mq
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:59Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744042
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-darwin-arm64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:59Z"
+            download_count: 5
+            id: 75744041
+            label: null
+            name: helm-v3.9.4-darwin-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Eg8Mp
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:59Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744041
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-darwin-arm64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:58Z"
+            download_count: 3
+            id: 75744040
+            label: null
+            name: helm-v3.9.4-darwin-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Eg8Mo
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:59Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744040
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-darwin-arm64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:58Z"
+            download_count: 3
+            id: 75744039
+            label: null
+            name: helm-v3.9.4-darwin-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eg8Mn
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:58Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744039
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-386.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:58Z"
+            download_count: 3
+            id: 75744038
+            label: null
+            name: helm-v3.9.4-linux-386.tar.gz.asc
+            node_id: RA_kwDOApspmc4Eg8Mm
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:58Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744038
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-386.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:58Z"
+            download_count: 3
+            id: 75744037
+            label: null
+            name: helm-v3.9.4-linux-386.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Eg8Ml
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:58Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744037
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-386.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:57Z"
+            download_count: 3
+            id: 75744036
+            label: null
+            name: helm-v3.9.4-linux-386.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eg8Mk
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:58Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744036
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-amd64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:57Z"
+            download_count: 16
+            id: 75744035
+            label: null
+            name: helm-v3.9.4-linux-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Eg8Mj
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744035
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-amd64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:57Z"
+            download_count: 15
+            id: 75744034
+            label: null
+            name: helm-v3.9.4-linux-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Eg8Mi
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744034
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-amd64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:57Z"
+            download_count: 3
+            id: 75744033
+            label: null
+            name: helm-v3.9.4-linux-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eg8Mh
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744033
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-arm.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:56Z"
+            download_count: 3
+            id: 75744029
+            label: null
+            name: helm-v3.9.4-linux-arm.tar.gz.asc
+            node_id: RA_kwDOApspmc4Eg8Md
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744029
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-arm.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:55Z"
+            download_count: 3
+            id: 75744028
+            label: null
+            name: helm-v3.9.4-linux-arm.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Eg8Mc
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744028
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-arm.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:55Z"
+            download_count: 3
+            id: 75744027
+            label: null
+            name: helm-v3.9.4-linux-arm.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eg8Mb
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744027
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-arm64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:56Z"
+            download_count: 8
+            id: 75744032
+            label: null
+            name: helm-v3.9.4-linux-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Eg8Mg
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744032
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-arm64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:56Z"
+            download_count: 8
+            id: 75744031
+            label: null
+            name: helm-v3.9.4-linux-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Eg8Mf
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744031
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-arm64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:56Z"
+            download_count: 3
+            id: 75744030
+            label: null
+            name: helm-v3.9.4-linux-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eg8Me
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744030
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-ppc64le.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:55Z"
+            download_count: 3
+            id: 75744026
+            label: null
+            name: helm-v3.9.4-linux-ppc64le.tar.gz.asc
+            node_id: RA_kwDOApspmc4Eg8Ma
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744026
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-ppc64le.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:55Z"
+            download_count: 3
+            id: 75744025
+            label: null
+            name: helm-v3.9.4-linux-ppc64le.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Eg8MZ
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744025
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-ppc64le.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:54Z"
+            download_count: 3
+            id: 75744024
+            label: null
+            name: helm-v3.9.4-linux-ppc64le.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eg8MY
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744024
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-s390x.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:54Z"
+            download_count: 3
+            id: 75744023
+            label: null
+            name: helm-v3.9.4-linux-s390x.tar.gz.asc
+            node_id: RA_kwDOApspmc4Eg8MX
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744023
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-s390x.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:54Z"
+            download_count: 3
+            id: 75744022
+            label: null
+            name: helm-v3.9.4-linux-s390x.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Eg8MW
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744022
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-linux-s390x.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:54Z"
+            download_count: 3
+            id: 75744021
+            label: null
+            name: helm-v3.9.4-linux-s390x.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eg8MV
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744021
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-windows-amd64.zip.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:53Z"
+            download_count: 3
+            id: 75744020
+            label: null
+            name: helm-v3.9.4-windows-amd64.zip.asc
+            node_id: RA_kwDOApspmc4Eg8MU
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744020
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-windows-amd64.zip.sha256.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:53Z"
+            download_count: 3
+            id: 75744019
+            label: null
+            name: helm-v3.9.4-windows-amd64.zip.sha256.asc
+            node_id: RA_kwDOApspmc4Eg8MT
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:53Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744019
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.9.4/helm-v3.9.4-windows-amd64.zip.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-08-24T19:28:53Z"
+            download_count: 3
+            id: 75744018
+            label: null
+            name: helm-v3.9.4-windows-amd64.zip.sha256sum.asc
+            node_id: RA_kwDOApspmc4Eg8MS
+            size: 833
+            state: uploaded
+            updated_at: "2022-08-24T19:28:53Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/75744018
+          assets_url: https://api.github.com/repos/helm/helm/releases/75268893/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+            events_url: https://api.github.com/users/mattfarina/events{/privacy}
+            followers_url: https://api.github.com/users/mattfarina/followers
+            following_url: https://api.github.com/users/mattfarina/following{/other_user}
+            gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/mattfarina
+            id: 62991
+            login: mattfarina
+            node_id: MDQ6VXNlcjYyOTkx
+            organizations_url: https://api.github.com/users/mattfarina/orgs
+            received_events_url: https://api.github.com/users/mattfarina/received_events
+            repos_url: https://api.github.com/users/mattfarina/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+            type: User
+            url: https://api.github.com/users/mattfarina
+          body: "Helm v3.9.4 is a security (patch) release. Users are strongly recommended
+            to update to this release.\r\n\r\nWhile fuzz testing Helm, provided by
+            the CNCF, a possible out of memory panic was discovered with the _strvals_
+            package. Out of memory panics cannot be recovered from in Go. This can
+            potentially be used to produce a denial of service (DOS). More details
+            are available in [the advisory](https://github.com/helm/helm/security/advisories/GHSA-7hfp-qfw3-5jxh).\r\n\r\nThe
+            community keeps growing, and we'd love to see you there!\r\n\r\n- Join
+            the discussion in [Kubernetes Slack](https://kubernetes.slack.com):\r\n
+            \ -  for questions and just to hang out\r\n  -  for discussing PRs, code,
+            and bugs\r\n- Hang out at the Public Developer Call: Thursday, 9:30 Pacific
+            via [Zoom](https://zoom.us/j/696660622)\r\n- Test, debug, and contribute
+            charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)\r\n\r\n##
+            Installation and Upgrading\r\n\r\nDownload Helm v3.9.4. The common platform
+            binaries are here:\r\n\r\n- [MacOS amd64](https://get.helm.sh/helm-v3.9.4-darwin-amd64.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.9.4-darwin-amd64.tar.gz.sha256sum)
+            / fe5930feca6fd1bd2c57df01c1f381c6444d1c3d2b857526bf6cbfbd6bf906b4)\r\n-
+            [MacOS arm64](https://get.helm.sh/helm-v3.9.4-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.4-darwin-arm64.tar.gz.sha256sum)
+            / a73d91751153169781b3ab5b4702ba1a2631fc8242eba33828b5905870059312)\r\n-
+            [Linux amd64](https://get.helm.sh/helm-v3.9.4-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.4-linux-amd64.tar.gz.sha256sum)
+            / 31960ff2f76a7379d9bac526ddf889fb79241191f1dbe2a24f7864ddcb3f6560)\r\n-
+            [Linux arm](https://get.helm.sh/helm-v3.9.4-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.4-linux-arm.tar.gz.sha256sum)
+            / 18ce0f79dcd927fea5b714ca03299929dad05266192d4cde3de6b4c4d4544249)\r\n-
+            [Linux arm64](https://get.helm.sh/helm-v3.9.4-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.4-linux-arm64.tar.gz.sha256sum)
+            / d24163e466f7884c55079d1050968e80a05b633830047116cdfd8ae28d35b0c0)\r\n-
+            [Linux i386](https://get.helm.sh/helm-v3.9.4-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.4-linux-386.tar.gz.sha256sum)
+            / a37b0070e2f072050fdf4bd7430ffbe55390fee410eb0781cd01a0fe206eb963)\r\n-
+            [Linux ppc64le](https://get.helm.sh/helm-v3.9.4-linux-ppc64le.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.9.4-linux-ppc64le.tar.gz.sha256sum)
+            / c63a951415c192397fda07c2f52aa60639b280920381c48d58be6803eb0c22f9)\r\n-
+            [Linux s390x](https://get.helm.sh/helm-v3.9.4-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.9.4-linux-s390x.tar.gz.sha256sum)
+            / 7fec97fa800d9bd981e2f42fb0908175db1f35da2d373a971ec7376fe4cb5451)\r\n-
+            [Windows amd64](https://get.helm.sh/helm-v3.9.4-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.9.4-windows-amd64.zip.sha256sum)
+            / 7cdc1342bc1863b6d5ce695fbef4d3b0d65c7c5bcef6ec6adf8fc9aa53821262)\r\n\r\nThis
+            release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36
+            B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina).
+            Please use the attached signatures for verifying this release using `gpg`.\r\n\r\nThe
+            [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you
+            going from there. For **upgrade instructions** or detailed installation
+            notes, check the [install guide](https://helm.sh/docs/intro/install/).
+            You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
+            on any system with `bash`.\r\n\r\n## What's Next\r\n\r\n- 3.10.0 is the
+            next feature release and will be on September 14, 2022"
+          created_at: "2022-08-24T18:45:42Z"
+          draft: false
+          html_url: https://github.com/helm/helm/releases/tag/v3.9.4
+          id: 75268893
+          mentions_count: 1
+          name: Helm 3.9.4
+          node_id: RE_kwDOApspmc4EfIMd
+          prerelease: false
+          published_at: "2022-08-24T20:00:15Z"
+          tag_name: v3.9.4
+          tarball_url: https://api.github.com/repos/helm/helm/tarball/v3.9.4
+          target_commitish: release-3.9
+          upload_url: https://uploads.github.com/repos/helm/helm/releases/75268893/assets{?name,label}
+          url: https://api.github.com/repos/helm/helm/releases/75268893
+          zipball_url: https://api.github.com/repos/helm/helm/zipball/v3.9.4
+      3.10.0:
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-darwin-amd64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:25:00Z"
+            download_count: 5
+            id: 78589575
+            label: null
+            name: helm-v3.10.0-darwin-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ery6H
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:25:00Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589575
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-darwin-amd64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:25:00Z"
+            download_count: 5
+            id: 78589574
+            label: null
+            name: helm-v3.10.0-darwin-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ery6G
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:25:00Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589574
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-darwin-amd64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:59Z"
+            download_count: 5
+            id: 78589573
+            label: null
+            name: helm-v3.10.0-darwin-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ery6F
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:25:00Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589573
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-darwin-arm64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:59Z"
+            download_count: 5
+            id: 78589572
+            label: null
+            name: helm-v3.10.0-darwin-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ery6E
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:59Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589572
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-darwin-arm64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:59Z"
+            download_count: 5
+            id: 78589571
+            label: null
+            name: helm-v3.10.0-darwin-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ery6D
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:59Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589571
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-darwin-arm64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:59Z"
+            download_count: 5
+            id: 78589570
+            label: null
+            name: helm-v3.10.0-darwin-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ery6C
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:59Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589570
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-386.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:58Z"
+            download_count: 6
+            id: 78589569
+            label: null
+            name: helm-v3.10.0-linux-386.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ery6B
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:59Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589569
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-386.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:58Z"
+            download_count: 5
+            id: 78589565
+            label: null
+            name: helm-v3.10.0-linux-386.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ery59
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:58Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589565
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-386.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:58Z"
+            download_count: 5
+            id: 78589563
+            label: null
+            name: helm-v3.10.0-linux-386.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ery57
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:58Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589563
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-amd64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:58Z"
+            download_count: 18
+            id: 78589562
+            label: null
+            name: helm-v3.10.0-linux-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ery56
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:58Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589562
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-amd64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:57Z"
+            download_count: 17
+            id: 78589560
+            label: null
+            name: helm-v3.10.0-linux-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ery54
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:58Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589560
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-amd64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:57Z"
+            download_count: 5
+            id: 78589559
+            label: null
+            name: helm-v3.10.0-linux-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ery53
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589559
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-arm.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:56Z"
+            download_count: 5
+            id: 78589555
+            label: null
+            name: helm-v3.10.0-linux-arm.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ery5z
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589555
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-arm.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:56Z"
+            download_count: 5
+            id: 78589554
+            label: null
+            name: helm-v3.10.0-linux-arm.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ery5y
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589554
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-arm.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:56Z"
+            download_count: 5
+            id: 78589553
+            label: null
+            name: helm-v3.10.0-linux-arm.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ery5x
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589553
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-arm64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:57Z"
+            download_count: 11
+            id: 78589558
+            label: null
+            name: helm-v3.10.0-linux-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ery52
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589558
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-arm64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:57Z"
+            download_count: 11
+            id: 78589557
+            label: null
+            name: helm-v3.10.0-linux-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ery51
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589557
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-arm64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:56Z"
+            download_count: 5
+            id: 78589556
+            label: null
+            name: helm-v3.10.0-linux-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ery50
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589556
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-ppc64le.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:55Z"
+            download_count: 4
+            id: 78589552
+            label: null
+            name: helm-v3.10.0-linux-ppc64le.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ery5w
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589552
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-ppc64le.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:55Z"
+            download_count: 4
+            id: 78589550
+            label: null
+            name: helm-v3.10.0-linux-ppc64le.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ery5u
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589550
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-ppc64le.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:55Z"
+            download_count: 4
+            id: 78589549
+            label: null
+            name: helm-v3.10.0-linux-ppc64le.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ery5t
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589549
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-s390x.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:55Z"
+            download_count: 4
+            id: 78589548
+            label: null
+            name: helm-v3.10.0-linux-s390x.tar.gz.asc
+            node_id: RA_kwDOApspmc4Ery5s
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589548
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-s390x.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:54Z"
+            download_count: 4
+            id: 78589547
+            label: null
+            name: helm-v3.10.0-linux-s390x.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4Ery5r
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589547
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-linux-s390x.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:54Z"
+            download_count: 4
+            id: 78589546
+            label: null
+            name: helm-v3.10.0-linux-s390x.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ery5q
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589546
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-windows-amd64.zip.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:54Z"
+            download_count: 5
+            id: 78589545
+            label: null
+            name: helm-v3.10.0-windows-amd64.zip.asc
+            node_id: RA_kwDOApspmc4Ery5p
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589545
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-windows-amd64.zip.sha256.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:54Z"
+            download_count: 5
+            id: 78589544
+            label: null
+            name: helm-v3.10.0-windows-amd64.zip.sha256.asc
+            node_id: RA_kwDOApspmc4Ery5o
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589544
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.0/helm-v3.10.0-windows-amd64.zip.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-09-21T17:24:52Z"
+            download_count: 4
+            id: 78589542
+            label: null
+            name: helm-v3.10.0-windows-amd64.zip.sha256sum.asc
+            node_id: RA_kwDOApspmc4Ery5m
+            size: 833
+            state: uploaded
+            updated_at: "2022-09-21T17:24:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/78589542
+          assets_url: https://api.github.com/repos/helm/helm/releases/77798500/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+            events_url: https://api.github.com/users/mattfarina/events{/privacy}
+            followers_url: https://api.github.com/users/mattfarina/followers
+            following_url: https://api.github.com/users/mattfarina/following{/other_user}
+            gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/mattfarina
+            id: 62991
+            login: mattfarina
+            node_id: MDQ6VXNlcjYyOTkx
+            organizations_url: https://api.github.com/users/mattfarina/orgs
+            received_events_url: https://api.github.com/users/mattfarina/received_events
+            repos_url: https://api.github.com/users/mattfarina/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+            type: User
+            url: https://api.github.com/users/mattfarina
+          body: "Helm v3.10.0 is a feature release. Users are encouraged to upgrade
+            for the best experience.\r\n\r\nThe community keeps growing, and we'd
+            love to see you there!\r\n\r\n- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):\r\n
+            \ -  for questions and just to hang out\r\n  -  for discussing PRs, code,
+            and bugs\r\n- Hang out at the Public Developer Call: Thursday, 9:30 Pacific
+            via [Zoom](https://zoom.us/j/696660622)\r\n- Test, debug, and contribute
+            charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)\r\n\r\n##
+            Notable Changes\r\n\r\n- Added --set-json flag to set json values.\r\n-
+            Added support `helm list --no-headers`\r\n- Added --burst-limit option
+            for client-side throttling limit configuration\r\n\r\n## Installation
+            and Upgrading\r\n\r\nDownload Helm v3.10.0. The common platform binaries
+            are here:\r\n\r\n- [MacOS amd64](https://get.helm.sh/helm-v3.10.0-darwin-amd64.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.10.0-darwin-amd64.tar.gz.sha256sum)
+            / 1e7fd528482ac2ef2d79fe300724b3e07ff6f846a2a9b0b0fe6f5fa05691786b)\r\n-
+            [MacOS arm64](https://get.helm.sh/helm-v3.10.0-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.0-darwin-arm64.tar.gz.sha256sum)
+            / f7f6558ebc8211824032a7fdcf0d55ad064cb33ec1eeec3d18057b9fe2e04dbe)\r\n-
+            [Linux amd64](https://get.helm.sh/helm-v3.10.0-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.0-linux-amd64.tar.gz.sha256sum)
+            / bf56beb418bb529b5e0d6d43d56654c5a03f89c98400b409d1013a33d9586474)\r\n-
+            [Linux arm](https://get.helm.sh/helm-v3.10.0-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.0-linux-arm.tar.gz.sha256sum)
+            / 1f756a2ea800dafb92fb77acc016220fdedee2be07630befd5ffd1410062b39c)\r\n-
+            [Linux arm64](https://get.helm.sh/helm-v3.10.0-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.0-linux-arm64.tar.gz.sha256sum)
+            / 3b72f5f8a60772fb156d0a4ab93272e8da7ef4d18e6421a7020d7c019f521fc1)\r\n-
+            [Linux i386](https://get.helm.sh/helm-v3.10.0-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.0-linux-386.tar.gz.sha256sum)
+            / 423159a7f49f1719dab78f78113ac5d8deae21f99491e79984c6363ae668428d)\r\n-
+            [Linux ppc64le](https://get.helm.sh/helm-v3.10.0-linux-ppc64le.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.10.0-linux-ppc64le.tar.gz.sha256sum)
+            / 90f49ef742bf36480b46073a11ca4244670e74f530bf507b488180fbf7334ef3)\r\n-
+            [Linux s390x](https://get.helm.sh/helm-v3.10.0-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.0-linux-s390x.tar.gz.sha256sum)
+            / f80733880529148c80f864cdb2d83ef26401b83176b8f4744ecddf4589cb4991)\r\n-
+            [Windows amd64](https://get.helm.sh/helm-v3.10.0-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.10.0-windows-amd64.zip.sha256sum)
+            / 9d841d55eb7cd6e07be0364bbfa85bceca7e184d50b43b13d20f044403937309)\r\n\r\nThis
+            release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36
+            B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina).
+            Please use the attached signatures for verifying this release using `gpg`.\r\n\r\nThe
+            [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you
+            going from there. For **upgrade instructions** or detailed installation
+            notes, check the [install guide](https://helm.sh/docs/intro/install/).
+            You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
+            on any system with `bash`.\r\n\r\n## What's Next\r\n\r\n- 3.10.1 will
+            contain only bug fixes and be released on October 12, 2022.\r\n- 3.11.0
+            is the next feature release and will be released on January 18, 2023\r\n\r\n##
+            Changelog\r\n\r\n- bump version to v3.10.0 ce66412a723e4d89555dc67217607c6579ffcb21
+            (Matt Farina)\r\n- Updating to Kubernetes 1.25 client libs 2108a23d347f238ce451c0014b9907963f2153ae
+            (Matt Farina)\r\n- Updating the certificates used for testing 7cbec356b4221239ecd4754d9f2c224fc3020e0d
+            (Matt Farina)\r\n- Updating index handling 225f8d7732aba378378e7507655157b1d26cd514
+            (Matt Farina)\r\n- Drop direct github.com/docker/docker dependency ea5365a3d10a5377f1515f3377fdf20e538168c2
+            (Mikhail Mazurskiy)\r\n- fix special string in the filename ece46c1d3a44e5f90cca0cbb96ae302dc47885cb
+            (d-d-up)\r\n- chore: add oci install description d1c0b7e0d099a75512f57ee83ee582d2d1da69c0
+            (longkai)\r\n- Fixing x509 test on darwin b3aa0b4118c20cc63d3da011199a346b9c92b386
+            (Matt Farina)\r\n- Bump k8s.io/kube-openapi to fix CVE-2022-1996 in github.com/emicklei/go-restful
+            1e0f8a4ee9991d1244b8576021011ef45982e955 (Guilherme Macedo)\r\n- fixes
+            #11142 missing array length check on release b9f347a574851d01f058663d7b65a108b9f980bc
+            (Arvid E. Picciani)\r\n- chore(deps): bump github.com/stretchr/testify
+            from 1.7.5 to 1.8.0 0c9de28b581f71ff1edbc336550860b05e594c63 (dependabot[bot])\r\n-
+            Upgrading to Kubernetes 1.24.2 211bd2b60a79dd6a8b4b79623c3df7bfa7b0f7e4
+            (Martin Hickey)\r\n- Bump Oras to 1.2.0 51e6c8e4e024486b6de1fb248119b46f020db9af
+            (Martin Hickey)\r\n- fix: use `go install` instead of `go get` aa6e82bac8db0b50766c03276dd0fed1bba6208c
+            (Matthew Fisher)\r\n- bump Go 1.18 39b0a82365a70d0a100783e1735a480e1aefcbc0
+            (yxxhero)\r\n- fix: improve logging & safety of statefulSetReady 7c74f1dd027709156c3345e1965693f04b8dd9ac
+            (Dominic Evans)\r\n- make token caching an opt in feature 42a04c76a48e6cdbd19debf042b2c9df34cf9ac6
+            (Soule BA)\r\n- chore(deps): bump github.com/stretchr/testify from 1.7.4
+            to 1.7.5 0acd81b43e95cc239e20f5bd6dcfaeb33dae8dc1 (dependabot[bot])\r\n-
+            chore(deps): bump github.com/rubenv/sql-migrate from 1.1.1 to 1.1.2 ccc104a208bfd612cee57b891dc71435d1c6434d
+            (dependabot[bot])\r\n- chore(deps): bump github.com/spf13/cobra from 1.4.0
+            to 1.5.0 (#11075) 3ff331fb14a998fd6c953bfb684337d8720f96ba (dependabot[bot])\r\n-
+            chore(deps): bump github.com/stretchr/testify from 1.7.1 to 1.7.4 994d78651176832c1d146291cabbd2ea8caf494f
+            (dependabot[bot])\r\n- Upgrading to Kubernetes 1.24.1 packages 5ef01c2714586dce761be5004f6752122044b1e1
+            (Matt Farina)\r\n- chore(deps): bump github.com/Masterminds/squirrel from
+            1.5.2 to 1.5.3 fe2a66c63c92f260c521b364800edab4e193a388 (dependabot[bot])\r\n-
+            feat(*): add flags/env for kube api tls overrides 687852e4feb50749eb64616e47446f1623e6d736
+            (Justen Walker)\r\n- Add --burst-limit option for client-side throttling
+            limit configuration (#10842) 823d92942119dfa07fd763bf6306bd67686811a8
+            (Igor Sutton)\r\n- chore(deps): bump github.com/lib/pq from 1.10.5 to
+            1.10.6 f3cfd4f6cc7ac0712f19c1767b1962c98e2bb3d7 (dependabot[bot])\r\n-
+            chore(deps): bump oras.land/oras-go from 1.1.0 to 1.1.1 a3bb2f71e09e64ecd3a7814e5043b730fc42966a
+            (dependabot[bot])\r\n- chore(deps): bump github.com/evanphx/json-patch
+            606633cc5e831532a093ec893a09fff325f1b3a9 (dependabot[bot])\r\n- Bump github.com/lib/pq
+            from 1.10.4 to 1.10.5 ede591f65d389e285ce6a61de894346c21f3418e (dependabot[bot])\r\n-
+            build(deps): bump github.com/containerd/containerd from 1.6.3 to 1.6.4
+            8b6904869a48118291a406b90bd98a01e12237ba (dependabot[bot])\r\n- build(deps):
+            bump github.com/docker/docker 67ed6e29991ef390e6e822491b52d4cbb3071e11
+            (dependabot[bot])\r\n- bump version to v3.9.0 1db28a2311bd4893d39679de708e5a77a751c4d2
+            (Matt Farina)\r\n- build(deps): bump github.com/jmoiron/sqlx from 1.3.4
+            to 1.3.5 43aa3132ff97ff4905397846715079ad68e0e2b6 (dependabot[bot])\r\n-
+            Bump github.com/BurntSushi/toml from 1.0.0 to 1.1.0 aafc920185be5024e66ddef17e69e385ba4122fb
+            (dependabot[bot])\r\n- Fixed helm uninstall not deleting the resource.
+            fe00c9296d50acc490dd08cd95eb014d37409716 (Mayank Thakur)\r\n- Fix UT d8c0e01132705b427d27835f9d3e2e8bb3e4da22
+            (stan-sz)\r\n- Fix linter 6c55d9e3e9f45afd576a9480fcad88d7d9d12ef5 (stan-sz)\r\n-
+            Update install.go a7e4ae752af018b357f551c653c2b39bc5720313 (stan-sz)\r\n-
+            Log error message on failed download 660e4ffe7aae8d33dfe869d01ae75156662365ac
+            (stan-sz)\r\n- Add support `helm list --no-headers` d76f86b01ccf734a134c99a6823bd435eb4401d8
+            (suzaku)\r\n- update go.mod d20c954819e77243e36528f268873d09097925d5 (yxxhero)\r\n-
+            fix --registry-config issue 9f199b6517c21394bca555983c70fc232d65014c (yxxhero)\r\n-
+            feat: add --set-json flag to set json values. 11e7d0cd73fb924d3347228c68d10ccdb123b6c6
+            (Luca Di Rocco)\r\n- fix(helm): ignore file-not-found error for `helm
+            repo list -o json` 94779dc99f266adde81882412ee944072da3b136 (Teo Klestrup
+            Röijezon)\r\n"
+          created_at: "2022-09-21T16:25:03Z"
+          draft: false
+          html_url: https://github.com/helm/helm/releases/tag/v3.10.0
+          id: 77798500
+          mentions_count: 1
+          name: Helm 3.10.0
+          node_id: RE_kwDOApspmc4Eoxxk
+          prerelease: false
+          published_at: "2022-09-21T17:32:35Z"
+          reactions:
+            "+1": 0
+            "-1": 0
+            confused: 0
+            eyes: 0
+            heart: 0
+            hooray: 2
+            laugh: 0
+            rocket: 2
+            total_count: 4
+            url: https://api.github.com/repos/helm/helm/releases/77798500/reactions
+          tag_name: v3.10.0
+          tarball_url: https://api.github.com/repos/helm/helm/tarball/v3.10.0
+          target_commitish: release-3.10
+          upload_url: https://uploads.github.com/repos/helm/helm/releases/77798500/assets{?name,label}
+          url: https://api.github.com/repos/helm/helm/releases/77798500
+          zipball_url: https://api.github.com/repos/helm/helm/zipball/v3.10.0
+      3.10.1:
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-darwin-amd64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:51:03Z"
+            download_count: 1
+            id: 80808336
+            label: null
+            name: helm-v3.10.1-darwin-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4E0QmQ
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:51:03Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80808336
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-darwin-amd64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:50Z"
+            download_count: 1
+            id: 80807921
+            label: null
+            name: helm-v3.10.1-darwin-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4E0Qfx
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:51Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807921
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-darwin-amd64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:51Z"
+            download_count: 1
+            id: 80807922
+            label: null
+            name: helm-v3.10.1-darwin-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4E0Qfy
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:51Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807922
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-darwin-arm64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:51Z"
+            download_count: 1
+            id: 80807923
+            label: null
+            name: helm-v3.10.1-darwin-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4E0Qfz
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:51Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807923
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-darwin-arm64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:51Z"
+            download_count: 1
+            id: 80807924
+            label: null
+            name: helm-v3.10.1-darwin-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4E0Qf0
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:51Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807924
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-darwin-arm64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:51Z"
+            download_count: 1
+            id: 80807925
+            label: null
+            name: helm-v3.10.1-darwin-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4E0Qf1
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:52Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807925
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-386.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:52Z"
+            download_count: 1
+            id: 80807926
+            label: null
+            name: helm-v3.10.1-linux-386.tar.gz.asc
+            node_id: RA_kwDOApspmc4E0Qf2
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:52Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807926
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-386.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:52Z"
+            download_count: 1
+            id: 80807927
+            label: null
+            name: helm-v3.10.1-linux-386.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4E0Qf3
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:52Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807927
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-386.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:52Z"
+            download_count: 1
+            id: 80807929
+            label: null
+            name: helm-v3.10.1-linux-386.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4E0Qf5
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:52Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807929
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-amd64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:52Z"
+            download_count: 19
+            id: 80807931
+            label: null
+            name: helm-v3.10.1-linux-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4E0Qf7
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:53Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807931
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-amd64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:53Z"
+            download_count: 13
+            id: 80807934
+            label: null
+            name: helm-v3.10.1-linux-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4E0Qf-
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:53Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807934
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-amd64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:53Z"
+            download_count: 1
+            id: 80807935
+            label: null
+            name: helm-v3.10.1-linux-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4E0Qf_
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:53Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807935
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-arm.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:54Z"
+            download_count: 1
+            id: 80807940
+            label: null
+            name: helm-v3.10.1-linux-arm.tar.gz.asc
+            node_id: RA_kwDOApspmc4E0QgE
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807940
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-arm.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:55Z"
+            download_count: 1
+            id: 80807941
+            label: null
+            name: helm-v3.10.1-linux-arm.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4E0QgF
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807941
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-arm.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:55Z"
+            download_count: 1
+            id: 80807942
+            label: null
+            name: helm-v3.10.1-linux-arm.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4E0QgG
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807942
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-arm64.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:53Z"
+            download_count: 10
+            id: 80807936
+            label: null
+            name: helm-v3.10.1-linux-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4E0QgA
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807936
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-arm64.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:54Z"
+            download_count: 9
+            id: 80807938
+            label: null
+            name: helm-v3.10.1-linux-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4E0QgC
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807938
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-arm64.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:54Z"
+            download_count: 1
+            id: 80807939
+            label: null
+            name: helm-v3.10.1-linux-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4E0QgD
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:54Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807939
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-ppc64le.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:55Z"
+            download_count: 2
+            id: 80807943
+            label: null
+            name: helm-v3.10.1-linux-ppc64le.tar.gz.asc
+            node_id: RA_kwDOApspmc4E0QgH
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:55Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807943
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-ppc64le.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:55Z"
+            download_count: 1
+            id: 80807944
+            label: null
+            name: helm-v3.10.1-linux-ppc64le.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4E0QgI
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807944
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-ppc64le.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:56Z"
+            download_count: 1
+            id: 80807945
+            label: null
+            name: helm-v3.10.1-linux-ppc64le.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4E0QgJ
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807945
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-s390x.tar.gz.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:56Z"
+            download_count: 2
+            id: 80807946
+            label: null
+            name: helm-v3.10.1-linux-s390x.tar.gz.asc
+            node_id: RA_kwDOApspmc4E0QgK
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807946
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-s390x.tar.gz.sha256.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:56Z"
+            download_count: 1
+            id: 80807948
+            label: null
+            name: helm-v3.10.1-linux-s390x.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4E0QgM
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:56Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807948
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-linux-s390x.tar.gz.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:56Z"
+            download_count: 1
+            id: 80807949
+            label: null
+            name: helm-v3.10.1-linux-s390x.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4E0QgN
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807949
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-windows-amd64.zip.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:57Z"
+            download_count: 1
+            id: 80807950
+            label: null
+            name: helm-v3.10.1-windows-amd64.zip.asc
+            node_id: RA_kwDOApspmc4E0QgO
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807950
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-windows-amd64.zip.sha256.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:57Z"
+            download_count: 1
+            id: 80807951
+            label: null
+            name: helm-v3.10.1-windows-amd64.zip.sha256.asc
+            node_id: RA_kwDOApspmc4E0QgP
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807951
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.1/helm-v3.10.1-windows-amd64.zip.sha256sum.asc
+            content_type: text/plain
+            created_at: "2022-10-12T20:44:57Z"
+            download_count: 1
+            id: 80807952
+            label: null
+            name: helm-v3.10.1-windows-amd64.zip.sha256sum.asc
+            node_id: RA_kwDOApspmc4E0QgQ
+            size: 833
+            state: uploaded
+            updated_at: "2022-10-12T20:44:57Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/80807952
+          assets_url: https://api.github.com/repos/helm/helm/releases/79689336/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+            events_url: https://api.github.com/users/mattfarina/events{/privacy}
+            followers_url: https://api.github.com/users/mattfarina/followers
+            following_url: https://api.github.com/users/mattfarina/following{/other_user}
+            gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/mattfarina
+            id: 62991
+            login: mattfarina
+            node_id: MDQ6VXNlcjYyOTkx
+            organizations_url: https://api.github.com/users/mattfarina/orgs
+            received_events_url: https://api.github.com/users/mattfarina/received_events
+            repos_url: https://api.github.com/users/mattfarina/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+            type: User
+            url: https://api.github.com/users/mattfarina
+          body: "Helm v3.10.1 is a patch release. Users are encouraged to upgrade
+            for the best experience. Users are encouraged to upgrade for the best
+            experience.\r\n\r\nThe community keeps growing, and we'd love to see you
+            there!\r\n\r\n- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):\r\n
+            \ -  for questions and just to hang out\r\n  -  for discussing PRs, code,
+            and bugs\r\n- Hang out at the Public Developer Call: Thursday, 9:30 Pacific
+            via [Zoom](https://zoom.us/j/696660622)\r\n- Test, debug, and contribute
+            charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)\r\n\r\n##
+            Installation and Upgrading\r\n\r\nDownload Helm v3.10.1. The common platform
+            binaries are here:\r\n\r\n- [MacOS amd64](https://get.helm.sh/helm-v3.10.1-darwin-amd64.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.10.1-darwin-amd64.tar.gz.sha256sum)
+            / e7f2db0df45a5011c1df8c82efde1e306a93a31eba4696d27cd751917e549ac6)\r\n-
+            [MacOS arm64](https://get.helm.sh/helm-v3.10.1-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.1-darwin-arm64.tar.gz.sha256sum)
+            / 28a079a61c393d125c5d5e1a8e20a04b72c709ccfa8e7822f3f17bb1ad2bbc22)\r\n-
+            [Linux amd64](https://get.helm.sh/helm-v3.10.1-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.1-linux-amd64.tar.gz.sha256sum)
+            / c12d2cd638f2d066fec123d0bd7f010f32c643afdf288d39a4610b1f9cb32af3)\r\n-
+            [Linux arm](https://get.helm.sh/helm-v3.10.1-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.1-linux-arm.tar.gz.sha256sum)
+            / 309f56a35185023262b4f20f7315d4e60854b517243444b34f5a458c81b33009)\r\n-
+            [Linux arm64](https://get.helm.sh/helm-v3.10.1-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.1-linux-arm64.tar.gz.sha256sum)
+            / d04b38d439ab8655abb4cb9ccc1efa8a3fe95f3f68af46d9137c6b7985491833)\r\n-
+            [Linux i386](https://get.helm.sh/helm-v3.10.1-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.1-linux-386.tar.gz.sha256sum)
+            / fb75a02d8a6e9ba6dd458f47dc0771a0f15c1842b6f6e2928c9136e676657993)\r\n-
+            [Linux ppc64le](https://get.helm.sh/helm-v3.10.1-linux-ppc64le.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.10.1-linux-ppc64le.tar.gz.sha256sum)
+            / 855ab37613b393c68d50b4355273df2322f27db08b1deca8807bac80343a8a64)\r\n-
+            [Linux s390x](https://get.helm.sh/helm-v3.10.1-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.1-linux-s390x.tar.gz.sha256sum)
+            / e51220b4582a3cad4b45330c96e1b0408d33e25f90a9e66b06649903acf1bed1)\r\n-
+            [Windows amd64](https://get.helm.sh/helm-v3.10.1-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.10.1-windows-amd64.zip.sha256sum)
+            / 4c6f89f005a86665e3e90c28d36446434945594aac960a8d5a2d1c4fb1e53522)\r\n\r\nThis
+            release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36
+            B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina).
+            Please use the attached signatures for verifying this release using `gpg`.\r\n\r\nThe
+            [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you
+            going from there. For **upgrade instructions** or detailed installation
+            notes, check the [install guide](https://helm.sh/docs/intro/install/).
+            You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
+            on any system with `bash`.\r\n\r\n## What's Next\r\n\r\n- 3.10.2 will
+            contain only bug fixes and be released on November 9, 2022\r\n- 3.11.1
+            is the next feature releaseand be released on January 18, 2023\r\n\r\n##
+            Changelog\r\n\r\n- Updating the deb location for azure cli 9f88ccb6aee40b9a0535fcc7efea6055e1ef72c9
+            (Matt Farina)\r\n- Updating the repo the azure cli is installed from a59afc47d6c6b7946f5734bb51a7d1cf2599a0c1
+            (Matt Farina)\r\n- Updating to kubernetes 1.25.2 packages 35af809b4db460a8834b05d78a58eddcfc236558
+            (Matt Farina)\r\n- one defer 97780c7ecc85dcb8e7ba302d50403152b2502ce6
+            (CI)\r\n- don't change r.CachePath 9f61b0a6bd8686a0c509ec0bd4ec4e449d930c19
+            (CI)\r\n- avoid adding new public function 75a1369794499daa7223271996781cadaf2c1adf
+            (CI)\r\n- fix tests 959acd8a1da38d33b5069f083a040fa237c04bfd (CI)\r\n-
+            fix: clean up temp files in FindChartInAuthAndTLSAndPassRepoURL (#11171)
+            f6830f7b0ab91909454fbdc476b4e760d6525abc (CI)\r\n- Allow CGO_ENABLED to
+            be overridden for build 91409241993efe6032e078d73f95163f0dc550bc (Joe
+            Julian)\r\n- update: Optimize the error message 23ff142d8b078287c3191260a10972699bf741a8
+            (wujunwei)\r\n- add nil judge for dependency , maintainers validate  and
+            some testcase. f22e26085ca44eef41f9c080374fcc056dd73cbb (wujunwei)\r\n-
+            Fix URL with encoded path support for ChartDownloader 4e075315f81311372568d73f2c929577d10c0de2
+            (Mathieu Parent)\r\n- fix: add cases.NoLower option for we can get same
+            effect to strings.Title 48444319694a4b6110541ef7bfea9a8627c1aa39 (wujunwei)\r\n-
+            Tolerate temporary errors from etcdserver 802a22903b9666aaba73a6e58602f4ff0dc9cf01
+            (Davanum Srinivas)\r\n"
+          created_at: "2022-10-12T20:12:43Z"
+          draft: false
+          html_url: https://github.com/helm/helm/releases/tag/v3.10.1
+          id: 79689336
+          mentions_count: 1
+          name: Helm 3.10.1
+          node_id: RE_kwDOApspmc4Ev_Z4
+          prerelease: false
+          published_at: "2022-10-12T20:51:20Z"
+          tag_name: v3.10.1
+          tarball_url: https://api.github.com/repos/helm/helm/tarball/v3.10.1
+          target_commitish: release-3.10
+          upload_url: https://uploads.github.com/repos/helm/helm/releases/79689336/assets{?name,label}
+          url: https://api.github.com/repos/helm/helm/releases/79689336
+          zipball_url: https://api.github.com/repos/helm/helm/zipball/v3.10.1
+      3.10.2:
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-amd64.tar.gz.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:16Z"
+            download_count: 2
+            id: 84166626
+            label: null
+            name: helm-v3.10.2-darwin-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4FBEfi
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:17Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166626
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-amd64.tar.gz.sha256.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:17Z"
+            download_count: 1
+            id: 84166628
+            label: null
+            name: helm-v3.10.2-darwin-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4FBEfk
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:17Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166628
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-amd64.tar.gz.sha256sum.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:17Z"
+            download_count: 1
+            id: 84166629
+            label: null
+            name: helm-v3.10.2-darwin-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4FBEfl
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:18Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166629
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-arm64.tar.gz.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:18Z"
+            download_count: 1
+            id: 84166630
+            label: null
+            name: helm-v3.10.2-darwin-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4FBEfm
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:18Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166630
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-arm64.tar.gz.sha256.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:18Z"
+            download_count: 1
+            id: 84166632
+            label: null
+            name: helm-v3.10.2-darwin-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4FBEfo
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:18Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166632
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-darwin-arm64.tar.gz.sha256sum.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:18Z"
+            download_count: 1
+            id: 84166633
+            label: null
+            name: helm-v3.10.2-darwin-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4FBEfp
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:19Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166633
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-386.tar.gz.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:19Z"
+            download_count: 1
+            id: 84166635
+            label: null
+            name: helm-v3.10.2-linux-386.tar.gz.asc
+            node_id: RA_kwDOApspmc4FBEfr
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:19Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166635
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-386.tar.gz.sha256.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:19Z"
+            download_count: 1
+            id: 84166636
+            label: null
+            name: helm-v3.10.2-linux-386.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4FBEfs
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:20Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166636
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-386.tar.gz.sha256sum.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:20Z"
+            download_count: 1
+            id: 84166637
+            label: null
+            name: helm-v3.10.2-linux-386.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4FBEft
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:20Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166637
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-amd64.tar.gz.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:20Z"
+            download_count: 26
+            id: 84166639
+            label: null
+            name: helm-v3.10.2-linux-amd64.tar.gz.asc
+            node_id: RA_kwDOApspmc4FBEfv
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:21Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166639
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-amd64.tar.gz.sha256.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:21Z"
+            download_count: 22
+            id: 84166640
+            label: null
+            name: helm-v3.10.2-linux-amd64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4FBEfw
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:21Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166640
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-amd64.tar.gz.sha256sum.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:21Z"
+            download_count: 1
+            id: 84166641
+            label: null
+            name: helm-v3.10.2-linux-amd64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4FBEfx
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:22Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166641
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm.tar.gz.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:22Z"
+            download_count: 1
+            id: 84166644
+            label: null
+            name: helm-v3.10.2-linux-arm.tar.gz.asc
+            node_id: RA_kwDOApspmc4FBEf0
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:22Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166644
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm.tar.gz.sha256.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:22Z"
+            download_count: 1
+            id: 84166645
+            label: null
+            name: helm-v3.10.2-linux-arm.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4FBEf1
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:22Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166645
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm.tar.gz.sha256sum.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:22Z"
+            download_count: 1
+            id: 84166646
+            label: null
+            name: helm-v3.10.2-linux-arm.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4FBEf2
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:23Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166646
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm64.tar.gz.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:23Z"
+            download_count: 13
+            id: 84166648
+            label: null
+            name: helm-v3.10.2-linux-arm64.tar.gz.asc
+            node_id: RA_kwDOApspmc4FBEf4
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:23Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166648
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm64.tar.gz.sha256.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:23Z"
+            download_count: 13
+            id: 84166649
+            label: null
+            name: helm-v3.10.2-linux-arm64.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4FBEf5
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:24Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166649
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-arm64.tar.gz.sha256sum.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:24Z"
+            download_count: 1
+            id: 84166651
+            label: null
+            name: helm-v3.10.2-linux-arm64.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4FBEf7
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:24Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166651
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-ppc64le.tar.gz.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:24Z"
+            download_count: 1
+            id: 84166654
+            label: null
+            name: helm-v3.10.2-linux-ppc64le.tar.gz.asc
+            node_id: RA_kwDOApspmc4FBEf-
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:25Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166654
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-ppc64le.tar.gz.sha256.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:25Z"
+            download_count: 1
+            id: 84166656
+            label: null
+            name: helm-v3.10.2-linux-ppc64le.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4FBEgA
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:25Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166656
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-ppc64le.tar.gz.sha256sum.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:25Z"
+            download_count: 1
+            id: 84166658
+            label: null
+            name: helm-v3.10.2-linux-ppc64le.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4FBEgC
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:26Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166658
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-s390x.tar.gz.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:26Z"
+            download_count: 1
+            id: 84166659
+            label: null
+            name: helm-v3.10.2-linux-s390x.tar.gz.asc
+            node_id: RA_kwDOApspmc4FBEgD
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:26Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166659
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-s390x.tar.gz.sha256.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:26Z"
+            download_count: 1
+            id: 84166662
+            label: null
+            name: helm-v3.10.2-linux-s390x.tar.gz.sha256.asc
+            node_id: RA_kwDOApspmc4FBEgG
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:26Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166662
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-linux-s390x.tar.gz.sha256sum.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:26Z"
+            download_count: 1
+            id: 84166663
+            label: null
+            name: helm-v3.10.2-linux-s390x.tar.gz.sha256sum.asc
+            node_id: RA_kwDOApspmc4FBEgH
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:27Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166663
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-windows-amd64.zip.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:27Z"
+            download_count: 2
+            id: 84166666
+            label: null
+            name: helm-v3.10.2-windows-amd64.zip.asc
+            node_id: RA_kwDOApspmc4FBEgK
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:27Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166666
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-windows-amd64.zip.sha256.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:27Z"
+            download_count: 1
+            id: 84166668
+            label: null
+            name: helm-v3.10.2-windows-amd64.zip.sha256.asc
+            node_id: RA_kwDOApspmc4FBEgM
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:28Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166668
+          - browser_download_url: https://github.com/helm/helm/releases/download/v3.10.2/helm-v3.10.2-windows-amd64.zip.sha256sum.asc
+            content_type: application/octet-stream
+            created_at: "2022-11-10T17:12:28Z"
+            download_count: 1
+            id: 84166670
+            label: null
+            name: helm-v3.10.2-windows-amd64.zip.sha256sum.asc
+            node_id: RA_kwDOApspmc4FBEgO
+            size: 833
+            state: uploaded
+            updated_at: "2022-11-10T17:12:28Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+              events_url: https://api.github.com/users/mattfarina/events{/privacy}
+              followers_url: https://api.github.com/users/mattfarina/followers
+              following_url: https://api.github.com/users/mattfarina/following{/other_user}
+              gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/mattfarina
+              id: 62991
+              login: mattfarina
+              node_id: MDQ6VXNlcjYyOTkx
+              organizations_url: https://api.github.com/users/mattfarina/orgs
+              received_events_url: https://api.github.com/users/mattfarina/received_events
+              repos_url: https://api.github.com/users/mattfarina/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+              type: User
+              url: https://api.github.com/users/mattfarina
+            url: https://api.github.com/repos/helm/helm/releases/assets/84166670
+          assets_url: https://api.github.com/repos/helm/helm/releases/82711070/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/62991?v=4
+            events_url: https://api.github.com/users/mattfarina/events{/privacy}
+            followers_url: https://api.github.com/users/mattfarina/followers
+            following_url: https://api.github.com/users/mattfarina/following{/other_user}
+            gists_url: https://api.github.com/users/mattfarina/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/mattfarina
+            id: 62991
+            login: mattfarina
+            node_id: MDQ6VXNlcjYyOTkx
+            organizations_url: https://api.github.com/users/mattfarina/orgs
+            received_events_url: https://api.github.com/users/mattfarina/received_events
+            repos_url: https://api.github.com/users/mattfarina/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mattfarina/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mattfarina/subscriptions
+            type: User
+            url: https://api.github.com/users/mattfarina
+          body: "Helm v3.10.2 is a patch release. Users are encouraged to upgrade
+            for the best experience. Users are encouraged to upgrade for the best
+            experience.\r\n\r\nThe community keeps growing, and we'd love to see you
+            there!\r\n\r\n- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):\r\n
+            \ -  for questions and just to hang out\r\n  -  for discussing PRs, code,
+            and bugs\r\n- Hang out at the Public Developer Call: Thursday, 9:30 Pacific
+            via [Zoom](https://zoom.us/j/696660622)\r\n- Test, debug, and contribute
+            charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)\r\n\r\n##
+            Installation and Upgrading\r\n\r\nDownload Helm v3.10.2. The common platform
+            binaries are here:\r\n\r\n- [MacOS amd64](https://get.helm.sh/helm-v3.10.2-darwin-amd64.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.10.2-darwin-amd64.tar.gz.sha256sum)
+            / e889960e4c1d7e2dfdb91b102becfaf22700cb86dc3e3553d9bebd7bab5a3803)\r\n-
+            [MacOS arm64](https://get.helm.sh/helm-v3.10.2-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-darwin-arm64.tar.gz.sha256sum)
+            / 460441eea1764ca438e29fa0e38aa0d2607402f753cb656a4ab0da9223eda494)\r\n-
+            [Linux amd64](https://get.helm.sh/helm-v3.10.2-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-amd64.tar.gz.sha256sum)
+            / 2315941a13291c277dac9f65e75ead56386440d3907e0540bf157ae70f188347)\r\n-
+            [Linux arm](https://get.helm.sh/helm-v3.10.2-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-arm.tar.gz.sha256sum)
+            / 25af344f46348958baa1c758cdf3b204ede3ddc483be1171ed3738d47efd0aae)\r\n-
+            [Linux arm64](https://get.helm.sh/helm-v3.10.2-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-arm64.tar.gz.sha256sum)
+            / 57fa17b6bb040a3788116557a72579f2180ea9620b4ee8a9b7244e5901df02e4)\r\n-
+            [Linux i386](https://get.helm.sh/helm-v3.10.2-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-386.tar.gz.sha256sum)
+            / ac9cbef2ec1237e2723ee8d3a92d1c4525a2da7cecc11336ba67de9bb6b473f0)\r\n-
+            [Linux ppc64le](https://get.helm.sh/helm-v3.10.2-linux-ppc64le.tar.gz)
+            ([checksum](https://get.helm.sh/helm-v3.10.2-linux-ppc64le.tar.gz.sha256sum)
+            / 53a578b84155d31c3e62dd93a88586b75e876dae82c7912c895ee5a574fa6209)\r\n-
+            [Linux s390x](https://get.helm.sh/helm-v3.10.2-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.10.2-linux-s390x.tar.gz.sha256sum)
+            / 33cb4a3382bea6bcd7eb7f385dd08941bdc84d0020345951eb467fbc8f5ccb60)\r\n-
+            [Windows amd64](https://get.helm.sh/helm-v3.10.2-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.10.2-windows-amd64.zip.sha256sum)
+            / f1a3190adecc26270bbef4f3ab2d1a56509f9d8df95413cdd6e3151f6f367862)\r\n\r\nThis
+            release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36
+            B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina).
+            Please use the attached signatures for verifying this release using `gpg`.\r\n\r\nThe
+            [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you
+            going from there. For **upgrade instructions** or detailed installation
+            notes, check the [install guide](https://helm.sh/docs/intro/install/).
+            You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3)
+            on any system with `bash`.\r\n\r\n## What's Next\r\n\r\n- 3.10.3 will
+            contain only bug fixes and be released on December 14, 2022\r\n- 3.11.0
+            is the next feature releaseand be released on January 18, 2023\r\n\r\n##
+            Changelog\r\n\r\n- fix a few function names on comments 50f003e5ee8704ec937a756c646870227d7c8b58
+            (cui fliter)\r\n- redirect registry client output to stderr c3a62f7880be8bdc904f2d54c4b0c16a86ec204c
+            (Cyril Jouve)\r\n- Readiness & liveness probes correct port 727bdf1813df73073d5a8eba4581201ef6518f93
+            (Peter Leong)"
+          created_at: "2022-11-10T14:53:00Z"
+          draft: false
+          html_url: https://github.com/helm/helm/releases/tag/v3.10.2
+          id: 82711070
+          mentions_count: 1
+          name: Helm v3.10.2
+          node_id: RE_kwDOApspmc4E7hIe
+          prerelease: false
+          published_at: "2022-11-10T17:13:10Z"
+          tag_name: v3.10.2
+          tarball_url: https://api.github.com/repos/helm/helm/tarball/v3.10.2
+          target_commitish: release-3.10
+          upload_url: https://uploads.github.com/repos/helm/helm/releases/82711070/assets{?name,label}
+          url: https://api.github.com/repos/helm/helm/releases/82711070
+          zipball_url: https://api.github.com/repos/helm/helm/zipball/v3.10.2
+    helmfile:
+      0.145.3:
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_checksums.txt
+            content_type: text/plain; charset=utf-8
+            created_at: "2022-08-16T02:02:26Z"
+            download_count: 0
+            id: 74822148
+            label: ""
+            name: helmfile_0.145.3_checksums.txt
+            node_id: RA_kwDOHEifes4EdbIE
+            size: 820
+            state: uploaded
+            updated_at: "2022-08-16T02:02:27Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/74822148
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_darwin_amd64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-16T02:02:24Z"
+            download_count: 0
+            id: 74822143
+            label: ""
+            name: helmfile_0.145.3_darwin_amd64.tar.gz
+            node_id: RA_kwDOHEifes4EdbH_
+            size: 11468903
+            state: uploaded
+            updated_at: "2022-08-16T02:02:25Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/74822143
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_darwin_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-16T02:02:24Z"
+            download_count: 0
+            id: 74822142
+            label: ""
+            name: helmfile_0.145.3_darwin_arm64.tar.gz
+            node_id: RA_kwDOHEifes4EdbH-
+            size: 11116726
+            state: uploaded
+            updated_at: "2022-08-16T02:02:25Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/74822142
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_linux_386.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-16T02:02:22Z"
+            download_count: 0
+            id: 74822137
+            label: ""
+            name: helmfile_0.145.3_linux_386.tar.gz
+            node_id: RA_kwDOHEifes4EdbH5
+            size: 10264043
+            state: uploaded
+            updated_at: "2022-08-16T02:02:23Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/74822137
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_linux_amd64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-16T02:02:25Z"
+            download_count: 15
+            id: 74822145
+            label: ""
+            name: helmfile_0.145.3_linux_amd64.tar.gz
+            node_id: RA_kwDOHEifes4EdbIB
+            size: 10968834
+            state: uploaded
+            updated_at: "2022-08-16T02:02:26Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/74822145
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_linux_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-16T02:02:25Z"
+            download_count: 4
+            id: 74822146
+            label: ""
+            name: helmfile_0.145.3_linux_arm64.tar.gz
+            node_id: RA_kwDOHEifes4EdbIC
+            size: 10043336
+            state: uploaded
+            updated_at: "2022-08-16T02:02:26Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/74822146
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_windows_386.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-16T02:02:23Z"
+            download_count: 0
+            id: 74822140
+            label: ""
+            name: helmfile_0.145.3_windows_386.tar.gz
+            node_id: RA_kwDOHEifes4EdbH8
+            size: 10729257
+            state: uploaded
+            updated_at: "2022-08-16T02:02:24Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/74822140
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_windows_amd64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-16T02:02:22Z"
+            download_count: 0
+            id: 74822136
+            label: ""
+            name: helmfile_0.145.3_windows_amd64.tar.gz
+            node_id: RA_kwDOHEifes4EdbH4
+            size: 11074355
+            state: uploaded
+            updated_at: "2022-08-16T02:02:23Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/74822136
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0.145.3/helmfile_0.145.3_windows_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-16T02:02:23Z"
+            download_count: 0
+            id: 74822138
+            label: ""
+            name: helmfile_0.145.3_windows_arm64.tar.gz
+            node_id: RA_kwDOHEifes4EdbH6
+            size: 10143997
+            state: uploaded
+            updated_at: "2022-08-16T02:02:24Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/74822138
+          assets_url: https://api.github.com/repos/helmfile/helmfile/releases/74471973/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/22009?v=4
+            events_url: https://api.github.com/users/mumoshu/events{/privacy}
+            followers_url: https://api.github.com/users/mumoshu/followers
+            following_url: https://api.github.com/users/mumoshu/following{/other_user}
+            gists_url: https://api.github.com/users/mumoshu/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/mumoshu
+            id: 22009
+            login: mumoshu
+            node_id: MDQ6VXNlcjIyMDA5
+            organizations_url: https://api.github.com/users/mumoshu/orgs
+            received_events_url: https://api.github.com/users/mumoshu/received_events
+            repos_url: https://api.github.com/users/mumoshu/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mumoshu/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mumoshu/subscriptions
+            type: User
+            url: https://api.github.com/users/mumoshu
+          body: "This release mainly contains fixes for a few regressions since our
+            migration to `cobra` as a CLI toolkit, the fix for a bug in OCI repo URL
+            parsing and the support for newer `helm-secrets`.\r\n\r\n## What's Changed\r\n*
+            Bump github.com/hashicorp/go-version from 1.4.0 to 1.6.0 by @dependabot
+            in https://github.com/helmfile/helmfile/pull/183\r\n* fix doc link error
+            and style error by @yxxhero in https://github.com/helmfile/helmfile/pull/217\r\n*
+            fix(doc): add missing version field in the release template example by
+            @lemeurherve in https://github.com/helmfile/helmfile/pull/228\r\n* update
+            readme about image repo and fix link error by @yxxhero in https://github.com/helmfile/helmfile/pull/224\r\n*
+            fix: use helm secrets view rather than helm secrets dec to decrypt by
+            @philomory in https://github.com/helmfile/helmfile/pull/201\r\n* add Go
+            lint by @yxxhero in https://github.com/helmfile/helmfile/pull/169\r\n*
+            Include the working helmfile ver in the bug report by @mumoshu in https://github.com/helmfile/helmfile/pull/237\r\n*
+            update Readmd.md by @yxxhero in https://github.com/helmfile/helmfile/pull/236\r\n*
+            feat: bump chartify to v0.10.0 to support OCI registry for adhoc dependencies
+            by @toVersus in https://github.com/helmfile/helmfile/pull/238\r\n* on
+            canary build, version should show \"0.0.0-dev\" by @itscaro in https://github.com/helmfile/helmfile/pull/162\r\n*
+            Add integration test for #238 with local docker registry as a OCI-based
+            helm chart repo by @mumoshu in https://github.com/helmfile/helmfile/pull/239\r\n*
+            chore: clean up snapshot test by @toVersus in https://github.com/helmfile/helmfile/pull/241\r\n*
+            doc: getting start adds repositories configuration by @xiaomudk in https://github.com/helmfile/helmfile/pull/240\r\n*
+            Use cobra by @yxxhero in https://github.com/helmfile/helmfile/pull/234\r\n*
+            E2E helmfile-template testing with local chart repo server by @mumoshu
+            in https://github.com/helmfile/helmfile/pull/245\r\n* correct --help cli
+            arg regression by @jouve in https://github.com/helmfile/helmfile/pull/252\r\n*
+            revert environment long option from --env to --environment by @jouve in
+            https://github.com/helmfile/helmfile/pull/250\r\n* test: Add unit tests
+            for ChartExport by @xiaomudk in https://github.com/helmfile/helmfile/pull/256\r\n*
+            test: Add unit tests for ChartPull by @xiaomudk in https://github.com/helmfile/helmfile/pull/257\r\n*
+            fix: OCI Url and Version parse error by @xiaomudk in https://github.com/helmfile/helmfile/pull/258\r\n*
+            Implement readDirEntries method by @vasicvuk in https://github.com/helmfile/helmfile/pull/254\r\n*
+            remove selector override in cmd/apply by @jouve in https://github.com/helmfile/helmfile/pull/266\r\n*
+            update doccs/index.md about CLI ref by @yxxhero in https://github.com/helmfile/helmfile/pull/264\r\n*
+            fix: needs error with context that includes slash by @sergeief in https://github.com/helmfile/helmfile/pull/268\r\n*
+            Bump k8s.io/apimachinery from 0.23.4 to 0.24.3 by @dependabot in https://github.com/helmfile/helmfile/pull/230\r\n*
+            Add flags about need for lint subcmd by @yxxhero in https://github.com/helmfile/helmfile/pull/273\r\n*
+            fix go.mod by @yxxhero in https://github.com/helmfile/helmfile/pull/275\r\n*
+            Refactor cobra flag default values for readability by @yxxhero in https://github.com/helmfile/helmfile/pull/274\r\n*
+            build(deps): bump go.uber.org/zap from 1.21.0 to 1.22.0 by @dependabot
+            in https://github.com/helmfile/helmfile/pull/280\r\n* Add file existence
+            check for remote values by @kuzaxak in https://github.com/helmfile/helmfile/pull/284\r\n*
+            Update ArchLinux installation instructions by @AnatolyRugalev in https://github.com/helmfile/helmfile/pull/282\r\n*
+            Fix Inclusion of Releases for Other Environments by @dackroyd in https://github.com/helmfile/helmfile/pull/276\r\n*
+            Cleanup pkg/config/config.go by @yxxhero in https://github.com/helmfile/helmfile/pull/287\r\n*
+            update golang lint by @yxxhero in https://github.com/helmfile/helmfile/pull/288\r\n*
+            Refactor 'images' workflow, include Ubuntu image to push by @pathob in
+            https://github.com/helmfile/helmfile/pull/262\r\n* build(deps): bump github.com/mattn/go-isatty
+            from 0.0.14 to 0.0.16 by @dependabot in https://github.com/helmfile/helmfile/pull/293\r\n*
+            fix tag miss in docker build by @yxxhero in https://github.com/helmfile/helmfile/pull/294\r\n\r\n##
+            New Contributors\r\n* @lemeurherve made their first contribution in https://github.com/helmfile/helmfile/pull/228\r\n*
+            @toVersus made their first contribution in https://github.com/helmfile/helmfile/pull/238\r\n*
+            @xiaomudk made their first contribution in https://github.com/helmfile/helmfile/pull/240\r\n*
+            @jouve made their first contribution in https://github.com/helmfile/helmfile/pull/252\r\n*
+            @vasicvuk made their first contribution in https://github.com/helmfile/helmfile/pull/254\r\n*
+            @sergeief made their first contribution in https://github.com/helmfile/helmfile/pull/268\r\n*
+            @kuzaxak made their first contribution in https://github.com/helmfile/helmfile/pull/284\r\n*
+            @AnatolyRugalev made their first contribution in https://github.com/helmfile/helmfile/pull/282\r\n*
+            @dackroyd made their first contribution in https://github.com/helmfile/helmfile/pull/276\r\n*
+            @pathob made their first contribution in https://github.com/helmfile/helmfile/pull/262\r\n\r\n**Full
+            Changelog**: https://github.com/helmfile/helmfile/compare/v0.145.2...v0.145.3"
+          created_at: "2022-08-16T01:41:33Z"
+          draft: false
+          html_url: https://github.com/helmfile/helmfile/releases/tag/v0.145.3
+          id: 74471973
+          mentions_count: 15
+          name: v0.145.3
+          node_id: RE_kwDOHEifes4EcFol
+          prerelease: false
+          published_at: "2022-08-16T01:52:39Z"
+          tag_name: v0.145.3
+          tarball_url: https://api.github.com/repos/helmfile/helmfile/tarball/v0.145.3
+          target_commitish: main
+          upload_url: https://uploads.github.com/repos/helmfile/helmfile/releases/74471973/assets{?name,label}
+          url: https://api.github.com/repos/helmfile/helmfile/releases/74471973
+          zipball_url: https://api.github.com/repos/helmfile/helmfile/zipball/v0.145.3
+      "0145.4":
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0145.4/helmfile_0145.4_checksums.txt
+            content_type: text/plain; charset=utf-8
+            created_at: "2022-08-24T22:16:46Z"
+            download_count: 0
+            id: 75758664
+            label: ""
+            name: helmfile_0145.4_checksums.txt
+            node_id: RA_kwDOHEifes4Eg_xI
+            size: 812
+            state: uploaded
+            updated_at: "2022-08-24T22:16:46Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/75758664
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0145.4/helmfile_0145.4_darwin_amd64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-24T22:16:45Z"
+            download_count: 0
+            id: 75758661
+            label: ""
+            name: helmfile_0145.4_darwin_amd64.tar.gz
+            node_id: RA_kwDOHEifes4Eg_xF
+            size: 11468956
+            state: uploaded
+            updated_at: "2022-08-24T22:16:46Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/75758661
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0145.4/helmfile_0145.4_darwin_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-24T22:16:45Z"
+            download_count: 0
+            id: 75758662
+            label: ""
+            name: helmfile_0145.4_darwin_arm64.tar.gz
+            node_id: RA_kwDOHEifes4Eg_xG
+            size: 11113155
+            state: uploaded
+            updated_at: "2022-08-24T22:16:46Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/75758662
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0145.4/helmfile_0145.4_linux_386.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-24T22:16:43Z"
+            download_count: 2
+            id: 75758654
+            label: ""
+            name: helmfile_0145.4_linux_386.tar.gz
+            node_id: RA_kwDOHEifes4Eg_w-
+            size: 10264427
+            state: uploaded
+            updated_at: "2022-08-24T22:16:44Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/75758654
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0145.4/helmfile_0145.4_linux_amd64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-24T22:16:42Z"
+            download_count: 7
+            id: 75758651
+            label: ""
+            name: helmfile_0145.4_linux_amd64.tar.gz
+            node_id: RA_kwDOHEifes4Eg_w7
+            size: 10969731
+            state: uploaded
+            updated_at: "2022-08-24T22:16:43Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/75758651
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0145.4/helmfile_0145.4_linux_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-24T22:16:42Z"
+            download_count: 5
+            id: 75758652
+            label: ""
+            name: helmfile_0145.4_linux_arm64.tar.gz
+            node_id: RA_kwDOHEifes4Eg_w8
+            size: 10043731
+            state: uploaded
+            updated_at: "2022-08-24T22:16:43Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/75758652
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0145.4/helmfile_0145.4_windows_386.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-24T22:16:44Z"
+            download_count: 0
+            id: 75758658
+            label: ""
+            name: helmfile_0145.4_windows_386.tar.gz
+            node_id: RA_kwDOHEifes4Eg_xC
+            size: 10728894
+            state: uploaded
+            updated_at: "2022-08-24T22:16:45Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/75758658
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0145.4/helmfile_0145.4_windows_amd64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-24T22:16:43Z"
+            download_count: 0
+            id: 75758655
+            label: ""
+            name: helmfile_0145.4_windows_amd64.tar.gz
+            node_id: RA_kwDOHEifes4Eg_w_
+            size: 11075005
+            state: uploaded
+            updated_at: "2022-08-24T22:16:44Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/75758655
+          - browser_download_url: https://github.com/helmfile/helmfile/releases/download/v0145.4/helmfile_0145.4_windows_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2022-08-24T22:16:44Z"
+            download_count: 0
+            id: 75758657
+            label: ""
+            name: helmfile_0145.4_windows_arm64.tar.gz
+            node_id: RA_kwDOHEifes4Eg_xB
+            size: 10143893
+            state: uploaded
+            updated_at: "2022-08-24T22:16:45Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+            url: https://api.github.com/repos/helmfile/helmfile/releases/assets/75758657
+          assets_url: https://api.github.com/repos/helmfile/helmfile/releases/75284604/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/22009?v=4
+            events_url: https://api.github.com/users/mumoshu/events{/privacy}
+            followers_url: https://api.github.com/users/mumoshu/followers
+            following_url: https://api.github.com/users/mumoshu/following{/other_user}
+            gists_url: https://api.github.com/users/mumoshu/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/mumoshu
+            id: 22009
+            login: mumoshu
+            node_id: MDQ6VXNlcjIyMDA5
+            organizations_url: https://api.github.com/users/mumoshu/orgs
+            received_events_url: https://api.github.com/users/mumoshu/received_events
+            repos_url: https://api.github.com/users/mumoshu/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mumoshu/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mumoshu/subscriptions
+            type: User
+            url: https://api.github.com/users/mumoshu
+          body: "This patch release is mainly about fixing `readDirEntries` added
+            in 0.145.3. @arkaitzj did a lot of awesome work along the way! We appreciate
+            your contribution ❤️ \r\nIn addition to the fix, this release also covers
+            fixes for a few diff-related flags that were not working since v0.145.0's
+            move to `cobra` as the CLI library. \r\n\r\n## What's Changed\r\n* Fix
+            for readDir selection, currently any template that uses readDir* functions
+            seems to break by @arkaitzj in https://github.com/helmfile/helmfile/pull/297\r\n*
+            Bring back --set flag to apply subcommand by @mjura in https://github.com/helmfile/helmfile/pull/298\r\n*
+            fix: return diff output config value by @mikelorant in https://github.com/helmfile/helmfile/pull/303\r\n*
+            fix: return diff context config value by @mikelorant in https://github.com/helmfile/helmfile/pull/301\r\n*
+            Fix some multi-value flags to not accept comma-separated values by @yxxhero
+            in https://github.com/helmfile/helmfile/pull/300\r\n* build(deps): bump
+            k8s.io/apimachinery from 0.24.3 to 0.24.4 by @dependabot in https://github.com/helmfile/helmfile/pull/306\r\n*
+            Add logo as .png and .ai (Adobe Illustrator) files by @pathob in https://github.com/helmfile/helmfile/pull/263\r\n*
+            Introduce Helmfile's own filesystem abstraction to correctly unit test
+            some components by @arkaitzj in https://github.com/helmfile/helmfile/pull/307\r\n*
+            fix typo for readme.md by @thenam153 in https://github.com/helmfile/helmfile/pull/312\r\n\r\n##
+            New Contributors\r\n* @arkaitzj made their first contribution in https://github.com/helmfile/helmfile/pull/297\r\n*
+            @mjura made their first contribution in https://github.com/helmfile/helmfile/pull/298\r\n*
+            @mikelorant made their first contribution in https://github.com/helmfile/helmfile/pull/303\r\n*
+            @thenam153 made their first contribution in https://github.com/helmfile/helmfile/pull/312\r\n\r\n**Full
+            Changelog**: https://github.com/helmfile/helmfile/compare/v0.145.3...v0145.4"
+          created_at: "2022-08-24T05:44:25Z"
+          draft: false
+          html_url: https://github.com/helmfile/helmfile/releases/tag/v0145.4
+          id: 75284604
+          mentions_count: 7
+          name: v0145.4
+          node_id: RE_kwDOHEifes4EfMB8
+          prerelease: false
+          published_at: "2022-08-24T22:06:45Z"
+          tag_name: v0145.4
+          tarball_url: https://api.github.com/repos/helmfile/helmfile/tarball/v0145.4
+          target_commitish: main
+          upload_url: https://uploads.github.com/repos/helmfile/helmfile/releases/75284604/assets{?name,label}
+          url: https://api.github.com/repos/helmfile/helmfile/releases/75284604
+          zipball_url: https://api.github.com/repos/helmfile/helmfile/zipball/v0145.4

--- a/argocd-helmfile-plugin/variant.mod
+++ b/argocd-helmfile-plugin/variant.mod
@@ -1,0 +1,24 @@
+provisioners:
+  files:
+    Dockerfile:
+      source: Dockerfile.tpl
+      arguments:
+        helm_version: "{{ .helm.version }}"
+        helmfile_version: "{{ .helmfile.version }}"
+    goss/goss.yaml:
+      source: goss/goss.yaml.tpl
+      arguments:
+        helm_version: "{{ .helm.version }}"
+        helmfile_version: "{{ .helmfile.version }}"
+
+dependencies:
+  helmfile:
+    releasesFrom:
+      githubReleases:
+        source: helmfile/helmfile
+    version: "> 0.1"
+  helm:
+    releasesFrom:
+      githubReleases:
+        source: helm/helm
+    version: "> 1.0"


### PR DESCRIPTION
- Add argocd-helmfile-plugin image
  - argocd plugin via sidecar https://argo-cd.readthedocs.io/en/latest/user-guide/config-management-plugins/
- Because argocd sidecar needs to work with argocd user (999) and I need to re-install helm plugins, I did not use the existing helmfile for base image.
  - https://argo-cd.readthedocs.io/en/latest/user-guide/config-management-plugins/
  - ![スクリーンショット 2022-11-30 17 17 16](https://user-images.githubusercontent.com/29860510/204743349-2fce3801-53f7-4ce6-9f00-f3d61fbd6607.png)
