### PR TITLE
Add arm for newrelic-php-agent

### DIFF
--- a/newrelic-php-agent/Dockerfile
+++ b/newrelic-php-agent/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.16
+FROM alpine:3.19
 
 ARG NR_VERSION=10.15.0.4
 ARG NR_FILE_NAME=newrelic-php5-${NR_VERSION}-linux-musl
 
 LABEL version="${NR_VERSION}"
-LABEL maintainer="niinuma@chatwork.com"
+LABEL maintainer="sakamoto@chatwork.com"
 
 COPY build/docker-* /usr/local/bin/
 

--- a/newrelic-php-agent/Dockerfile.arm64
+++ b/newrelic-php-agent/Dockerfile.arm64
@@ -1,0 +1,1 @@
+Dockerfile

--- a/newrelic-php-agent/Makefile
+++ b/newrelic-php-agent/Makefile
@@ -12,11 +12,11 @@ esac)
 
 .PHONY: build
 build:
-	@docker buildx build -t chatwork/`basename $$PWD`:latest --platform linux/${PLATFORM} -f Dockerfile --load .;
-	@version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`); \
-		if [ -n "$$version" ]; then \
-			docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
-		fi
+	@docker buildx build -t chatwork/`basename $$PWD`:latest --platform linux/${PLATFORM} -f Dockerfile --load .; \
+	version=$$(docker inspect -f {{.Config.Labels.version}} chatwork/`basename $$PWD`:latest); \
+	if [ -n "$$version" ]; then \
+		docker tag chatwork/`basename $$PWD`:latest chatwork/`basename $$PWD`:$$version; \
+	fi
 
 .PHONY: check
 check:
@@ -28,8 +28,8 @@ check:
 	@echo "\033[92mno problem.\033[0m";
 
 .PHONY: test
-test:
-	docker-compose -f docker-compose.test.yml up --build --no-start sut
+test: build
+	docker-compose -f docker-compose.test.yml up --no-start sut
 	docker cp $(shell pwd)/goss `basename $$PWD`:/goss
 	docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
 
@@ -39,6 +39,5 @@ push:
 		if docker inspect --format='{{index .RepoDigests 0}}' chatwork/$$(basename $$PWD):$$version >/dev/null 2>&1; then \
 			echo "no changes"; \
 		else \
-			docker push chatwork/`basename $$PWD`:latest; \
-			docker push chatwork/`basename $$PWD`:$$version; \
+			docker buildx build -t chatwork/`basename $$PWD`:$$version -t chatwork/`basename $$PWD`:latest --platform linux/amd64,linux/arm64 -f Dockerfile --push .; \
 		fi

--- a/newrelic-php-agent/docker-compose.test.yml
+++ b/newrelic-php-agent/docker-compose.test.yml
@@ -5,11 +5,12 @@ services:
       context: .
     image: chatwork/newrelic-php-agent
   sut:
-    image: kiwicom/dgoss
+    image: chatwork/dgoss:latest
     environment:
       GOSS_FILES_PATH: /goss
       GOSS_FILES_STRATEGY: cp
-    command: /usr/local/bin/dgoss run --entrypoint '' chatwork/newrelic-php-agent tail -f /dev/null
+    entrypoint: ""
+    command: /usr/local/bin/dgoss run --entrypoint tail chatwork/newrelic-php-agent -f /dev/null
     container_name: newrelic-php-agent
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
- The `install_daemon` in Dockerfile determines the architecture and installs the appropriate binary.

```
[~/Downloads/newrelic-php5-10.15.0.4-linux-musl] <git-user: cw-sakamoto>
=> 9:25 % ll agent/
total 0
drwxr-xr-x@  4 cw-sakamoto  staff  128  1 18 09:25 .
drwxr-xr-x@ 10 cw-sakamoto  staff  320  1 17 17:35 ..
drwxr-xr-x@  6 cw-sakamoto  staff  192 12 19 07:59 aarch64
drwxr-xr-x@ 11 cw-sakamoto  staff  352 12 19 07:59 x64
```
