### PR TITLE
[fluentd]delete google-cloud-api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2.1
 executors:
   arm64:
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2204:2024.01.1
       # The same volume is set for amd64 and arm64.
       # see https://circleci.com/docs/2.0/docker-layer-caching/
       docker_layer_caching: false
     resource_class: arm.medium
   x86_64:
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2204:2024.01.1
       # The same volume is set for amd64 and arm64.
       # see https://circleci.com/docs/2.0/docker-layer-caching/
       docker_layer_caching: false

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -17,12 +17,11 @@ RUN buildDeps="make gcc g++ libc-dev ruby-dev" \
     && fluent-gem install fluent-plugin-s3 -v "1.7.2" \
     && fluent-gem install fluent-plugin-rewrite-tag-filter -v "2.4.0" \
     # kubernetes plugins
-    && fluent-gem install fluent-plugin-kubernetes_metadata_filter -v "3.2.0" \
+    && fluent-gem install fluent-plugin-kubernetes_metadata_filter -v "3.4.0" \
     && fluent-gem install fluent-plugin-prometheus -v "2.1.0" \
     # aws plugin
     && fluent-gem install fluent-plugin-ec2-metadata -v "0.1.3" \
     # gcp plugin
-    && fluent-gem install fluent-plugin-google-cloud -v "0.13.0" \
     && fluent-gem install fluent-plugin-bigquery -v "3.1.0" \
     # other plugin
     && fluent-gem install fluent-plugin-detect-exceptions -v "0.0.14" \

--- a/fluentd/Dockerfile.tpl
+++ b/fluentd/Dockerfile.tpl
@@ -17,12 +17,11 @@ RUN buildDeps="make gcc g++ libc-dev ruby-dev" \
     && fluent-gem install fluent-plugin-s3 -v "1.7.2" \
     && fluent-gem install fluent-plugin-rewrite-tag-filter -v "2.4.0" \
     # kubernetes plugins
-    && fluent-gem install fluent-plugin-kubernetes_metadata_filter -v "3.2.0" \
+    && fluent-gem install fluent-plugin-kubernetes_metadata_filter -v "3.4.0" \
     && fluent-gem install fluent-plugin-prometheus -v "2.1.0" \
     # aws plugin
     && fluent-gem install fluent-plugin-ec2-metadata -v "0.1.3" \
     # gcp plugin
-    && fluent-gem install fluent-plugin-google-cloud -v "0.13.0" \
     && fluent-gem install fluent-plugin-bigquery -v "3.1.0" \
     # other plugin
     && fluent-gem install fluent-plugin-detect-exceptions -v "0.0.14" \


### PR DESCRIPTION
- Remove `fluent-plugin-google-cloud` plugins to omit the following logs
```
W, [2024-03-04T05:11:58.090129 #25]  WARN -- : OpenCensus support is now deprecated. Please refer https://github.com/googleapis/google-api-ruby-client#tracing for migrating to use OpenTelemetry.
```
- bump `fluent-plugin-kubernetes_metadata_filter`
- bump circleci ubuntu https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177
