### PR TITLE
Migrate integration-test workflows from CircleCI to Github Actions

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,61 @@
+name: Update dependencies
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CW_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.CW_DOCKER_HUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      # TODO: Replace docker-compose in each Makefile and then delete it.
+      - name: Add docker-compose
+        run: |
+          mkdir -p /home/runner/.local/bin
+          cat << EOT >> /home/runner/.local/bin/docker-compose
+          #!/bin/bash
+          docker compose "\$@"
+          EOT
+          chmod +x /home/runner/.local/bin/docker-compose
+      - run: make ci:diff
+      - run: |
+          ARCH=`make arch`
+          EXTENSION=`make extension`
+
+          make ci:diff | while read DIR; do
+            cd ${GITHUB_WORKSPACE}/${DIR}
+            if find . -type l -o -type f -name "Dockerfile${EXTENSION}" | grep Dockerfile ; then
+              make build;
+              make test;
+            else
+              echo "${DIR} is ${ARCH} not supported. make build & make test was skipped.";
+            fi
+          done
+      - name: Notification failed
+        if: failure() && github.actor == 'github-actions[bot]'
+        run: |
+          GITHUB_JOB_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          # TODO: Delete it once you have completed the migration from CircleCI.
+          export CIRCLE_BUILD_URL="${GITHUB_JOB_URL}"
+          make ci:notify -e TITLE="Github Actions: Failed to CI of PR created by automatic update of dependency (devil) arch: $(make arch)" \
+            -e BODY="${{ github.event.pull_request.html_url }}"
+        env:
+          CHATWORK_API_TOKEN: ${{ secrets.CHATWORK_API_TOKEN }}
+          CHATWORK_NOTIFICATION_ROOM_ID: ${{ secrets.CHATWORK_NOTIFICATION_ROOM_ID }}


### PR DESCRIPTION
Migrate integration-test workflows from CircleCI to Github Actions.

Do not delete the test job on the CircleCI side.