### PR TITLE
Change GITHUB_TOKEN to PAT

### DIFF
--- a/.github/workflows/auto_merge.yaml
+++ b/.github/workflows/auto_merge.yaml
@@ -29,7 +29,7 @@ jobs:
               -l 'state == `"open"`' \
               -l 'base.ref == `"master"`' \
               -l 'starts_with(head.ref, `"mod-up-"`)' \
-              -l 'user.login == `"github-actions[bot]"`' \
+              -l 'user.login == `"cw-circleci"`' \
               -l 'length(statuses[?context == `"ci/circleci: test-arm64"` && state == `"success"`]) == `1`' \
               -l 'length(statuses[?context == `"ci/circleci: test-x86_64"` && state == `"success"`]) == `1`' 2> ./error.log
 
@@ -38,7 +38,7 @@ jobs:
             exit 1
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SELF_GITHUB_TOKEN }}
   notify:
     needs: merge
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,10 +2,6 @@ name: Integration
 
 on:
   push:
-    branches:
-      - '**'
-    tags:
-      - '**'
   workflow_dispatch:
 
 jobs:
@@ -53,7 +49,7 @@ jobs:
             fi
           done
       - name: Notification failed
-        if: failure() && github.actor == 'github-actions[bot]'
+        if: failure() && github.actor == 'cw-circleci'
         run: |
           GITHUB_JOB_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           # TODO: Delete it once you have completed the migration from CircleCI.

--- a/.github/workflows/update_dependecies.yaml
+++ b/.github/workflows/update_dependecies.yaml
@@ -32,11 +32,11 @@ jobs:
           mkdir -p ~/bin
           mv ./mod ~/bin/
 
-          git config --global user.email "server_admin+cw-github@chatwork.com"
+          git config --global user.email "${{ secrets.BOT_EMAIL }}"
           git config --global user.name "github-actions"
           ls */variant.mod | xargs -I{} dirname {} | xargs -I{} /bin/bash -c 'cd {} && ~/bin/mod up --build  --pull-request --base master --branch 'mod-up-{}' --title "[{}] update" --skip-on-duplicate-pull-request-title'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SELF_GITHUB_TOKEN }}
       - name: Notification failed
         if: failure()
         run: |


### PR DESCRIPTION
Changed GITHUB_TOKEN to PAT because branch creation from a bot does not trigger the Github Actions workflow.