### PR TITLE
Build claude-code manifest from registry tags directly

### DIFF
--- a/claude-code/Makefile
+++ b/claude-code/Makefile
@@ -42,17 +42,17 @@ push:
 .PHONY: manifest\:push
 manifest\:push:
 	@version=$$(docker inspect -f {{.Config.Labels.version}} $(call image_ref,latest)); \
-		if docker inspect --format='{{index .RepoDigests 0}}' $(call image_ref,$$version) >/dev/null 2>&1; then \
+		if docker buildx imagetools inspect $(call image_ref,$$version) >/dev/null 2>&1; then \
 			echo "no changes"; \
 		else \
-			docker pull $(call image_ref,$$version,$(ARM64_SUFFIX)); \
-			docker pull $(call image_ref,$$version,$(AMD64_SUFFIX)); \
-			arm64_digest=$$(docker inspect -f '{{index .RepoDigests 0}}' $(call image_ref,$$version,$(ARM64_SUFFIX))); \
-			amd64_digest=$$(docker inspect -f '{{index .RepoDigests 0}}' $(call image_ref,$$version,$(AMD64_SUFFIX))); \
-			docker buildx imagetools create -t $(call image_ref,$$version) $$arm64_digest $$amd64_digest; \
-			docker buildx imagetools create -t $(call image_ref,latest) $$arm64_digest $$amd64_digest; \
-			hub-tool tag rm $(call image_ref,$$version,$(ARM64_SUFFIX)) -f; \
-			hub-tool tag rm $(call image_ref,$$version,$(AMD64_SUFFIX)) -f; \
+			docker buildx imagetools create -t $(call image_ref,$$version) \
+				$(call image_ref,$$version,$(ARM64_SUFFIX)) \
+				$(call image_ref,$$version,$(AMD64_SUFFIX)); \
+			docker buildx imagetools create -t $(call image_ref,latest) \
+				$(call image_ref,$$version,$(ARM64_SUFFIX)) \
+				$(call image_ref,$$version,$(AMD64_SUFFIX)); \
+			hub-tool tag rm $(call image_ref,$$version,$(ARM64_SUFFIX)) -f || true; \
+			hub-tool tag rm $(call image_ref,$$version,$(AMD64_SUFFIX)) -f || true; \
 		fi
 
 .PHONY: manifest\:succeed-message


### PR DESCRIPTION
## Summary
- Replace `docker pull` + `docker inspect` digest flow in `claude-code/Makefile` `manifest:push` with `docker buildx imagetools create` against the per-arch registry tags directly.
- Switch the idempotency check to `docker buildx imagetools inspect` so the host's docker daemon state is no longer queried.
- Tolerate `hub-tool tag rm` failures so a token-scope error does not fail the job after the multi-arch tag is already published.

## Why
On the previous PR (#4206), the `manifest` job failed with `Error: No such object: chatwork/claude-code:<version>-aarch64`. Root cause: the workflow's `manifest` job runs on `ubuntu-latest` (amd64) and does **not** run `docker/setup-qemu-action` (only `setup-buildx-action`). `docker pull` of a single-arch arm64 image on an amd64 host without QEMU does not create a usable local tag, so the subsequent `docker inspect` returns "No such object" and the manifest creation fails.

`docker buildx imagetools create` operates on registry references directly, so it does not depend on the runner's platform support. This sidesteps the missing QEMU setup without changing the shared workflow.

## Test plan
- [ ] CI `manifest` job for this PR completes successfully and publishes `chatwork/claude-code:<version>` and `chatwork/claude-code:latest` as multi-arch manifests.
- [ ] `hub-tool tag rm` may still fail under the current Docker Hub token scope, but `|| true` keeps the job green; the per-arch suffix tags will linger until the token scope is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)