### PR TITLE
actions-runner-helmfile: rebuild on gha-runner-scale-set (new ARC) base

### DIFF
--- a/actions-runner-helmfile/Dockerfile
+++ b/actions-runner-helmfile/Dockerfile
@@ -1,48 +1,45 @@
-ARG RUNNER_VERSION=2.309.0-ubuntu-22.04-ead26ab
-FROM summerwind/actions-runner:v${RUNNER_VERSION}
+ARG RUNNER_VERSION=2.334.0
+FROM ghcr.io/actions/actions-runner:${RUNNER_VERSION}
 
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG RUNNER_VERSION=2.309.0-ubuntu-22.04-ead26ab
-ARG KUBECTL_VERSION=1.28.2
+ARG RUNNER_VERSION=2.334.0
+ARG KUBECTL_VERSION=1.36.0
 ARG HELMFILE_VERSION=1.5.0
 ARG HELM_VERSION=4.1.4
 ARG HELM_FILE_NAME=helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz
 ARG HELMFILE_FILE_NAME=helmfile_${HELMFILE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
-ARG KUSTOMIZE_VERSION=4.5.7
+ARG KUSTOMIZE_VERSION=5.8.1
 ARG KUSTOMIZE_FILE_NAME=kustomize_v${KUSTOMIZE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
-ARG HELM_DIFF_VERSION=3.12.0
-ARG HELM_SECRETS_VERSION=4.6.5
-ARG HELM_GIT_VERSION=0.13.0
-ARG YQ_VERSION=4.34.1
+ARG HELM_DIFF_VERSION=3.15.6
+ARG HELM_SECRETS_VERSION=4.7.6
+ARG HELM_GIT_VERSION=1.5.2
+ARG YQ_VERSION=4.53.2
 ARG YQ_FILE_NAME=yq_${TARGETOS}_${TARGETARCH}
 
 LABEL version="v${RUNNER_VERSION}-v${HELMFILE_VERSION}-v${HELM_VERSION}"
 LABEL maintainer="sakamoto@chatwork.com"
 
-WORKDIR /
-
 USER root
 
-# https://github.com/actions/actions-runner-controller/blob/master/runner/actions-runner.ubuntu-22.04.dockerfile#L15
-RUN apt update -y \
-    && apt install gh wget -y \
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends gh wget ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 ADD https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/${YQ_FILE_NAME} /tmp
 RUN mv /tmp/${YQ_FILE_NAME} /usr/local/bin/yq \
-  && chmod 755 /usr/local/bin/yq
+    && chmod 755 /usr/local/bin/yq
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /tmp
+ADD https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /tmp
 RUN mv /tmp/kubectl /usr/local/bin/kubectl \
-  && chmod 755 /usr/local/bin/kubectl
+    && chmod 755 /usr/local/bin/kubectl
 
 ADD https://get.helm.sh/${HELM_FILE_NAME} /tmp
 RUN tar -zxvf /tmp/${HELM_FILE_NAME} -C /tmp \
-  && mv /tmp/${TARGETOS}-${TARGETARCH}/helm /usr/local/bin/helm \
-  && chmod 755 /usr/local/bin/helm \
-  && rm -rf /tmp/*
+    && mv /tmp/${TARGETOS}-${TARGETARCH}/helm /usr/local/bin/helm \
+    && chmod 755 /usr/local/bin/helm \
+    && rm -rf /tmp/*
 
 ADD https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILE_NAME} /tmp
 RUN tar -zxf /tmp/${KUSTOMIZE_FILE_NAME} -C /tmp \
@@ -51,17 +48,13 @@ RUN tar -zxf /tmp/${KUSTOMIZE_FILE_NAME} -C /tmp \
     && rm -fr /tmp/*
 
 ADD https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/${HELMFILE_FILE_NAME} /tmp
-
 RUN tar -zxvf /tmp/${HELMFILE_FILE_NAME} -C /tmp \
-  && mv /tmp/helmfile /usr/local/bin/helmfile \
-  && chmod 755 /usr/local/bin/helmfile \
-  && rm -rf /tmp/*
+    && mv /tmp/helmfile /usr/local/bin/helmfile \
+    && chmod 755 /usr/local/bin/helmfile \
+    && rm -rf /tmp/*
 
 USER runner
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} --verify=false \
     && helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION} --verify=false \
     && helm plugin install https://github.com/aslafy-z/helm-git.git --version v${HELM_GIT_VERSION} --verify=false
-
-ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["entrypoint.sh"]

--- a/actions-runner-helmfile/Dockerfile.tpl
+++ b/actions-runner-helmfile/Dockerfile.tpl
@@ -1,48 +1,45 @@
 ARG RUNNER_VERSION={{ .runner_version }}
-FROM summerwind/actions-runner:v${RUNNER_VERSION}
+FROM ghcr.io/actions/actions-runner:${RUNNER_VERSION}
 
 ARG TARGETOS
 ARG TARGETARCH
 
 ARG RUNNER_VERSION={{ .runner_version }}
-ARG KUBECTL_VERSION=1.28.2
+ARG KUBECTL_VERSION=1.36.0
 ARG HELMFILE_VERSION={{ .helmfile_version }}
 ARG HELM_VERSION={{ .helm_version }}
 ARG HELM_FILE_NAME=helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz
 ARG HELMFILE_FILE_NAME=helmfile_${HELMFILE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
-ARG KUSTOMIZE_VERSION=4.5.7
+ARG KUSTOMIZE_VERSION=5.8.1
 ARG KUSTOMIZE_FILE_NAME=kustomize_v${KUSTOMIZE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz
-ARG HELM_DIFF_VERSION=3.12.0
-ARG HELM_SECRETS_VERSION=4.6.5
-ARG HELM_GIT_VERSION=0.13.0
-ARG YQ_VERSION=4.34.1
+ARG HELM_DIFF_VERSION=3.15.6
+ARG HELM_SECRETS_VERSION=4.7.6
+ARG HELM_GIT_VERSION=1.5.2
+ARG YQ_VERSION=4.53.2
 ARG YQ_FILE_NAME=yq_${TARGETOS}_${TARGETARCH}
 
 LABEL version="v${RUNNER_VERSION}-v${HELMFILE_VERSION}-v${HELM_VERSION}"
 LABEL maintainer="sakamoto@chatwork.com"
 
-WORKDIR /
-
 USER root
 
-# https://github.com/actions/actions-runner-controller/blob/master/runner/actions-runner.ubuntu-22.04.dockerfile#L15
-RUN apt update -y \
-    && apt install gh wget -y \
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends gh wget ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 ADD https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/${YQ_FILE_NAME} /tmp
 RUN mv /tmp/${YQ_FILE_NAME} /usr/local/bin/yq \
-  && chmod 755 /usr/local/bin/yq
+    && chmod 755 /usr/local/bin/yq
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /tmp
+ADD https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /tmp
 RUN mv /tmp/kubectl /usr/local/bin/kubectl \
-  && chmod 755 /usr/local/bin/kubectl
+    && chmod 755 /usr/local/bin/kubectl
 
 ADD https://get.helm.sh/${HELM_FILE_NAME} /tmp
 RUN tar -zxvf /tmp/${HELM_FILE_NAME} -C /tmp \
-  && mv /tmp/${TARGETOS}-${TARGETARCH}/helm /usr/local/bin/helm \
-  && chmod 755 /usr/local/bin/helm \
-  && rm -rf /tmp/*
+    && mv /tmp/${TARGETOS}-${TARGETARCH}/helm /usr/local/bin/helm \
+    && chmod 755 /usr/local/bin/helm \
+    && rm -rf /tmp/*
 
 ADD https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILE_NAME} /tmp
 RUN tar -zxf /tmp/${KUSTOMIZE_FILE_NAME} -C /tmp \
@@ -51,17 +48,13 @@ RUN tar -zxf /tmp/${KUSTOMIZE_FILE_NAME} -C /tmp \
     && rm -fr /tmp/*
 
 ADD https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/${HELMFILE_FILE_NAME} /tmp
-
 RUN tar -zxvf /tmp/${HELMFILE_FILE_NAME} -C /tmp \
-  && mv /tmp/helmfile /usr/local/bin/helmfile \
-  && chmod 755 /usr/local/bin/helmfile \
-  && rm -rf /tmp/*
+    && mv /tmp/helmfile /usr/local/bin/helmfile \
+    && chmod 755 /usr/local/bin/helmfile \
+    && rm -rf /tmp/*
 
 USER runner
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v${HELM_DIFF_VERSION} --verify=false \
     && helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION} --verify=false \
     && helm plugin install https://github.com/aslafy-z/helm-git.git --version v${HELM_GIT_VERSION} --verify=false
-
-ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["entrypoint.sh"]

--- a/actions-runner-helmfile/variant.mod
+++ b/actions-runner-helmfile/variant.mod
@@ -25,7 +25,7 @@ dependencies:
     version: "> 1.0"
   runner:
     releasesFrom:
-      validVersionPattern: "[0-9]+\\.[0-9]+\\.[0-9]+-ubuntu-22.04+"
-      dockerImageTags:
-        source: summerwind/actions-runner
-    version: "~ 2.309.0-ubuntu-22.04-ead26ab"
+      validVersionPattern: "[0-9]+\\.[0-9]+\\.[0-9]+"
+      githubReleases:
+        source: actions/runner
+    version: "> 2.309.0"


### PR DESCRIPTION
## Summary

The `chatwork/actions-runner-helmfile` image was previously based on `summerwind/actions-runner`, which is incompatible with the new ARC (`gha-runner-scale-set`). This PR rebuilds the image on `ghcr.io/actions/actions-runner` so the runner can be deployed via the new ARC chart.

The new ARC chart provides `/home/runner/run.sh` as the container command, so the legacy `ENTRYPOINT ["/bin/bash", "-c"]` + `CMD ["entrypoint.sh"]` pattern is dropped and the chart-supplied command takes effect.

`variant.mod` is updated to source the runner version from the `actions/runner` GitHub Releases instead of the `summerwind/actions-runner` Docker Hub tags. The version pattern and constraint are aligned with the new SemVer-only tag scheme.

Tooling versions bumped to current stable:

| Tool | Old | New |
|---|---|---|
| runner | 2.309.0-ubuntu-22.04-ead26ab | 2.334.0 |
| kubectl | 1.28.2 | 1.36.0 |
| kustomize | 4.5.7 | 5.8.1 |
| helm-diff | 3.12.0 | 3.15.6 |
| helm-secrets | 4.6.5 | 4.7.6 |
| helm-git | 0.13.0 | 1.5.2 |
| yq | 4.34.1 | 4.53.2 |
| helm | 4.1.4 | (already current) |
| helmfile | 1.4.4 | (already current) |

Other minor cleanup:

- `apt` -> `apt-get` with `--no-install-recommends`, add `ca-certificates` explicitly
- kubectl source -> official `dl.k8s.io` (was `storage.googleapis.com`)

Once merged, the new image will be published as `chatwork/actions-runner-helmfile:v2.334.0-v1.4.4-v4.1.4` to Docker Hub by the existing CI push job.

## Test plan

- [ ] CI Integration workflow `test` job passes (build + goss test) on both linux/amd64 and linux/arm64
- [ ] After merge, CI `push` job publishes `chatwork/actions-runner-helmfile:v2.334.0-v1.4.4-v4.1.4` to Docker Hub
- [ ] `docker pull chatwork/actions-runner-helmfile:v2.334.0-v1.4.4-v4.1.4 && docker run --rm chatwork/actions-runner-helmfile:v2.334.0-v1.4.4-v4.1.4 helmfile -v` works locally
- [ ] The image is consumed downstream by the `chatwork/helmfiles` ranner migration (separate PR; the runner Pod registers and runs `helmfile-diff/apply` jobs successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)