### PR TITLE
refactor(claude-code): trim base image down to the bare minimum

### DIFF
--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -4,33 +4,13 @@ ARG CLAUDE_CODE_VERSION=2.1.142
 
 LABEL version="${CLAUDE_CODE_VERSION}"
 
-# Common dependencies
+# Pure-minimum: only what the Claude Code CLI installer and TLS-based usage
+# require. Anything plugin-specific (git, python3, awscli, gh, yq, jq, ...)
+# is the extension image's responsibility.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
-    git \
-    jq \
-    unzip \
-    python3 \
-    awscli \
-    gpg \
-    openssh-client \
     bash \
-    less \
-    && rm -rf /var/lib/apt/lists/*
-
-# yq (latest)
-RUN curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)" \
-      -o /usr/local/bin/yq \
-    && chmod +x /usr/local/bin/yq
-
-# GitHub CLI
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-      > /etc/apt/sources.list.d/github-cli.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user

--- a/claude-code/Dockerfile.arm64
+++ b/claude-code/Dockerfile.arm64
@@ -1,36 +1,16 @@
 FROM debian:bookworm-slim
 
-ARG CLAUDE_CODE_VERSION=2.1.105
+ARG CLAUDE_CODE_VERSION=2.1.142
 
 LABEL version="${CLAUDE_CODE_VERSION}"
 
-# Common dependencies
+# Pure-minimum: only what the Claude Code CLI installer and TLS-based usage
+# require. Anything plugin-specific (git, python3, awscli, gh, yq, jq, ...)
+# is the extension image's responsibility.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
-    git \
-    jq \
-    unzip \
-    python3 \
-    awscli \
-    gpg \
-    openssh-client \
     bash \
-    less \
-    && rm -rf /var/lib/apt/lists/*
-
-# yq (latest)
-RUN curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$(dpkg --print-architecture)" \
-      -o /usr/local/bin/yq \
-    && chmod +x /usr/local/bin/yq
-
-# GitHub CLI
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-      > /etc/apt/sources.list.d/github-cli.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -1,6 +1,6 @@
 # claude-code
 
-A base Docker image for running [Claude Code](https://claude.ai/code) in containers. Provides the Claude Code CLI and common dependencies pre-installed.
+A base Docker image for running [Claude Code](https://claude.ai/code) in containers. Provides only the Claude Code CLI and the minimum TLS-capable runtime; anything plugin-specific is the extension image's responsibility.
 
 This image is designed to be used as a base (`FROM chatwork/claude-code`) by teams building their own plugin marketplace runner images, or directly in Kubernetes CronJobs.
 
@@ -37,12 +37,10 @@ $ docker run --rm chatwork/claude-code claude --version
 
 ## Included
 
-| Category | Tools |
-|---|---|
-| Core | Claude Code CLI, curl, ca-certificates, git, bash, less |
-| Data processing | jq, yq, unzip |
-| Cloud / CI | awscli, gh (GitHub CLI), python3 |
-| Security | gpg, openssh-client |
+- Claude Code CLI (Native Install) under `/home/claude/.local/bin/claude`
+- `curl`, `ca-certificates`, `bash` — required by the installer and TLS-based runtime usage
+
+That's it. Plugin-specific tooling (`git`, `python3`, `jq`, `yq`, `gh`, `awscli`, ...) is intentionally **not** bundled here; extension images install what they need.
 
 ## Version management
 

--- a/claude-code/goss/goss.yaml
+++ b/claude-code/goss/goss.yaml
@@ -6,17 +6,3 @@ command:
     exit-status: 0
     stdout:
       - 2.1.142
-  git --version:
-    exit-status: 0
-  jq --version:
-    exit-status: 0
-  python3 --version:
-    exit-status: 0
-  yq --version:
-    exit-status: 0
-  gh --version:
-    exit-status: 0
-  gpg --version:
-    exit-status: 0
-  aws --version:
-    exit-status: 0


### PR DESCRIPTION
## Summary

Narrow the `claude-code` base image's responsibility to "run the Claude Code CLI". Plugin-specific tooling (`git`, `jq`, `python3`, `awscli`, `gpg`, `openssh-client`, `unzip`, `less`, `yq`, `gh`) is moved out of the base and becomes the extension image's responsibility — teams install only what they actually need on top of this base.

This cuts the image down by ~48% (886MB → 463MB on linux/arm64).

## Changes

- `claude-code/Dockerfile` and `claude-code/Dockerfile.arm64`: apt install layer reduced to `curl`, `ca-certificates`, `bash` (everything the CLI installer and a TLS-capable runtime needs). The standalone `yq` and `gh` install layers are removed.
- `claude-code/goss/goss.yaml`: drop assertions for tools that no longer ship in the image; keep the existence + version check for the Claude Code CLI itself.
- `claude-code/README.md`: documentation updated to reflect the minimal surface and the explicit hand-off to extension images.

## Why

Most consumers wrap this base in their own extension image (e.g. a marketplace runner). Bundling a fixed superset of tooling here ends up being the lowest common denominator: too much for some teams (paying for `awscli` ~200MB they never touch), still missing things for others (no Node.js, no team-specific clients). Pushing all of that decision down to the extension image keeps the shared base small and ships exactly what each team needs.

## Local verification

linux/arm64:

| | before | after |
|---|---:|---:|
| `apt-get install` layer | 308MB | 16.3MB |
| `yq` layer | 12.8MB | 0 |
| `gh` layer | 37.6MB | 0 |
| **total image** | **889MB** | **463MB** |

```
$ docker buildx build -t chatwork/claude-code:slim-test --platform linux/arm64 -f Dockerfile --load .
$ docker tag chatwork/claude-code:slim-test chatwork/claude-code:latest
$ docker-compose -f docker-compose.test.yml up --no-start sut
$ docker cp $(pwd)/goss claude-code:/goss
$ docker-compose -f docker-compose.test.yml up --no-recreate --exit-code-from sut sut
...
claude-code  | File: /home/claude/.local/bin/claude: exists: matches expectation: true
claude-code  | Command: claude --version: exit-status: matches expectation: 0
claude-code  | Command: claude --version: stdout: matches expectation: ["2.1.142"]
claude-code  | Count: 3, Failed: 0, Skipped: 0
```

## Test plan

- [ ] CI / image build green for both `Dockerfile` and `Dockerfile.arm64`
- [ ] Downstream extension images that previously assumed the bundled tooling are updated to install what they need (no implicit dependency on git/python3/awscli/etc. in this base)

## Notes for downstream consumers

If your extension image previously relied on tools like `git`, `python3`, `awscli`, `gh`, `yq`, `jq`, `gpg`, `openssh-client`, `unzip`, or `less` being present in the base, add them to your own `Dockerfile` going forward.