### PR TITLE
ci: skip Docker Hub login on PRs from forks

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -32,6 +32,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Login to Docker Hub
+        # Skip on PRs from forks (secrets are not available).
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.CW_DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
## Summary

- GitHub Actions does not expose secrets to workflows triggered by PRs from forked repositories. As a result, `docker/login-action` in the `test` job fails with `Username and password required` for external contributors' PRs (see [PR #4292 run](https://github.com/chatwork/dockerfiles/actions/runs/25883069866/job/76645765156?pr=4292)).
- Skip the Docker Hub login step when the PR head repo is not this repository.
- The `push` and `manifest` jobs are guarded by `if: github.ref_name == 'master'` and never run on fork PRs, so they are unaffected.

### Why skipping the login is safe for the `test` job

- The `test` job only runs `make build` / `make test` and never pushes, so authentication is not strictly required.
- All base images referenced by `Dockerfile*` in this repository are public — Docker Hub library images (`alpine`, `ubuntu`, `mysql`, `python`, `ruby`, `node`, `debian`, `busybox`, `docker`, ...), public vendor images (`amazon/aws-cli`, `datadog/...`, `confluentinc/...`, `crossplane/...`, `summerwind/actions-runner`, `adoptopenjdk/*`, `circleci/*`, `fluent/fluentd`, `curlimages/curl`), GHCR (`ghcr.io/actions/actions-runner`), Quay (`quay.io/argoproj/argocd`), and the project's own publicly-pushed `chatwork/*` images. None of them require authentication.
- Without login, anonymous pulls are subject to Docker Hub's rate limit, but the impact is limited because this only affects fork PRs (internal PRs and pushes to `master` still log in as before). If it ever becomes a real problem we can revisit (e.g. registry mirror, or asking maintainers to retrigger CI from an internal branch).