### PR TITLE
[conftest][atlantis-aws] Fix conftest download URL for renamed release assets

### DIFF
--- a/atlantis-aws/Dockerfile
+++ b/atlantis-aws/Dockerfile
@@ -1,11 +1,11 @@
-FROM chatwork/aws:2.34.15
+FROM chatwork/aws:2.34.49
 
 ARG TARGETARCH
-ARG ATLANTIS_VERSION=0.42.0
+ARG ATLANTIS_VERSION=0.46.0
 ARG GOSU_VERSION=1.19
 ARG GIT_LFS_VERSION=3.7.1
 ARG DUMB_INIT_VERSION=1.2.5
-ENV DEFAULT_TERRAFORM_VERSION=1.14.7
+ENV DEFAULT_TERRAFORM_VERSION=1.15.7
 LABEL version="${ATLANTIS_VERSION}"
 LABEL maintainer="sakamoto@chatwork.com"
 
@@ -34,10 +34,15 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.11 0.15.5 1.0.11 1
     done && \
     ln -s "/usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform" /usr/local/bin/terraform
 
-ARG CONFTEST_VERSION=0.67.0
-ARG CONFTEST_RPM_FILE="conftest_${CONFTEST_VERSION}_linux_${TARGETARCH}.rpm"
+ARG CONFTEST_VERSION=0.68.2
 
-RUN curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/${CONFTEST_RPM_FILE} && \
+RUN case "${TARGETARCH}" in \
+        "amd64") CONFTEST_ARCH=x86_64 ;; \
+        "arm64") CONFTEST_ARCH=arm64 ;; \
+        *) echo "ERROR: 'TARGETARCH' value expected: ${TARGETARCH}"; exit 1 ;; \
+    esac && \
+    CONFTEST_RPM_FILE="conftest_${CONFTEST_VERSION}_Linux_${CONFTEST_ARCH}.rpm" && \
+    curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/${CONFTEST_RPM_FILE} && \
     rpm -i ./${CONFTEST_RPM_FILE} && \
     rm -f ./${CONFTEST_RPM_FILE}
 

--- a/atlantis-aws/Dockerfile.tpl
+++ b/atlantis-aws/Dockerfile.tpl
@@ -35,9 +35,14 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.11 0.15.5 1.0.11 1
     ln -s "/usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform" /usr/local/bin/terraform
 
 ARG CONFTEST_VERSION={{ .conftest_version }}
-ARG CONFTEST_RPM_FILE="conftest_${CONFTEST_VERSION}_linux_${TARGETARCH}.rpm"
 
-RUN curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/${CONFTEST_RPM_FILE} && \
+RUN case "${TARGETARCH}" in \
+        "amd64") CONFTEST_ARCH=x86_64 ;; \
+        "arm64") CONFTEST_ARCH=arm64 ;; \
+        *) echo "ERROR: 'TARGETARCH' value expected: ${TARGETARCH}"; exit 1 ;; \
+    esac && \
+    CONFTEST_RPM_FILE="conftest_${CONFTEST_VERSION}_Linux_${CONFTEST_ARCH}.rpm" && \
+    curl -LOs https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/${CONFTEST_RPM_FILE} && \
     rpm -i ./${CONFTEST_RPM_FILE} && \
     rm -f ./${CONFTEST_RPM_FILE}
 

--- a/atlantis-aws/goss/goss.yaml
+++ b/atlantis-aws/goss/goss.yaml
@@ -21,19 +21,19 @@ command:
   /usr/local/bin/aws --version:
     exit-status: 0
     stdout:
-      - 2.34.15
+      - 2.34.49
   /usr/bin/conftest --version:
     exit-status: 0
     stdout:
-      - 0.67.0
+      - 0.68.2
   /usr/local/bin/terraform --version:
     exit-status: 0
     stdout:
-      - 1.14.7
+      - 1.15.7
   /usr/local/bin/atlantis version:
     exit-status: 0
     stdout:
-      - 0.42.0
+      - 0.46.0
   /usr/bin/git-lfs --version:
     exit-status: 0
     stdout:

--- a/atlantis-aws/variant.lock
+++ b/atlantis-aws/variant.lock
@@ -1,7 +1,7 @@
 dependencies:
   atlantis:
-    version: 0.40.0
-    previousVersion: 0.39.0
+    version: 0.46.0
+    previousVersion: 0.40.0
     versions:
     - 0.19.8
     - 0.19.9
@@ -43,20 +43,21 @@ dependencies:
     - 0.38.0
     - 0.39.0
     - 0.40.0
+    - 0.46.0
     githubRelease:
       assets:
-      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.40.0/atlantis_darwin_amd64.zip
+      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_darwin_amd64.zip
         content_type: application/zip
-        created_at: "2026-01-30T05:47:12Z"
-        digest: sha256:70c125a61468d39455374e8e4f3adc68bce57c0787f92bd93d5f7d787db1e1f5
-        download_count: 1
-        id: 348054297
+        created_at: "2026-06-30T16:11:07Z"
+        digest: sha256:bb07800649c411e3de561af89fecc128c448a72569de542bae8c208f262120aa
+        download_count: 16
+        id: 462311780
         label: ""
         name: atlantis_darwin_amd64.zip
-        node_id: RA_kwDOBy76Zc4UvuMZ
-        size: 12944684
+        node_id: RA_kwDOBy76Zc4bjlFk
+        size: 14756418
         state: uploaded
-        updated_at: "2026-01-30T05:47:13Z"
+        updated_at: "2026-06-30T16:11:08Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -77,19 +78,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/348054297
-      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.40.0/atlantis_darwin_arm64.zip
+        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311780
+      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_darwin_arm64.zip
         content_type: application/zip
-        created_at: "2026-01-30T05:47:12Z"
-        digest: sha256:e10189a13f4b8be1f084df6b1e3d3e90cbecf8c99f5d943f893c7f6039fe8c04
-        download_count: 1
-        id: 348054300
+        created_at: "2026-06-30T16:11:07Z"
+        digest: sha256:b5c176d90b03c9d11123b047b61129e0ca77c3ba3cf97f5fb51e2faeb2e84ed3
+        download_count: 20
+        id: 462311783
         label: ""
         name: atlantis_darwin_arm64.zip
-        node_id: RA_kwDOBy76Zc4UvuMc
-        size: 12015568
+        node_id: RA_kwDOBy76Zc4bjlFn
+        size: 13666416
         state: uploaded
-        updated_at: "2026-01-30T05:47:13Z"
+        updated_at: "2026-06-30T16:11:08Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -110,19 +111,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/348054300
-      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.40.0/atlantis_linux_386.zip
+        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311783
+      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_linux_386.zip
         content_type: application/zip
-        created_at: "2026-01-30T05:47:12Z"
-        digest: sha256:376d39b8df85c6db2791265551867542809a63480a72e02bffc167cc66b421f9
-        download_count: 1
-        id: 348054299
+        created_at: "2026-06-30T16:11:05Z"
+        digest: sha256:89857be16cb5627bf5f8dd4b5eb1c94c05ab4b39653303aea37ef09539b117df
+        download_count: 2
+        id: 462311743
         label: ""
         name: atlantis_linux_386.zip
-        node_id: RA_kwDOBy76Zc4UvuMb
-        size: 11900967
+        node_id: RA_kwDOBy76Zc4bjlE_
+        size: 13517849
         state: uploaded
-        updated_at: "2026-01-30T05:47:13Z"
+        updated_at: "2026-06-30T16:11:07Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -143,19 +144,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/348054299
-      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.40.0/atlantis_linux_amd64.zip
+        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311743
+      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_linux_amd64.zip
         content_type: application/zip
-        created_at: "2026-01-30T05:47:13Z"
-        digest: sha256:f9d9106d4c2e71764cdd9019334df0dd02bcf010b1e8d551969df8a3d28106fe
-        download_count: 3
-        id: 348054304
+        created_at: "2026-06-30T16:11:05Z"
+        digest: sha256:00b04241be663ab0302eaad606149e2c3e11f8413beef9b51d838837839c05be
+        download_count: 167
+        id: 462311748
         label: ""
         name: atlantis_linux_amd64.zip
-        node_id: RA_kwDOBy76Zc4UvuMg
-        size: 12658513
+        node_id: RA_kwDOBy76Zc4bjlFE
+        size: 14401237
         state: uploaded
-        updated_at: "2026-01-30T05:47:14Z"
+        updated_at: "2026-06-30T16:11:06Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -176,19 +177,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/348054304
-      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.40.0/atlantis_linux_arm.zip
+        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311748
+      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_linux_arm.zip
         content_type: application/zip
-        created_at: "2026-01-30T05:47:12Z"
-        digest: sha256:e31a341b8ede4ca5ac34c46242262a800bec1e3fe0584446dacd7ca55683ee6e
+        created_at: "2026-06-30T16:11:07Z"
+        digest: sha256:e19ed55172ec13fff5547b7974f63a51d68cc0d441a934178054f602e4e7fcb8
         download_count: 1
-        id: 348054296
+        id: 462311772
         label: ""
         name: atlantis_linux_arm.zip
-        node_id: RA_kwDOBy76Zc4UvuMY
-        size: 11870714
+        node_id: RA_kwDOBy76Zc4bjlFc
+        size: 13459034
         state: uploaded
-        updated_at: "2026-01-30T05:47:13Z"
+        updated_at: "2026-06-30T16:11:08Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -209,19 +210,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/348054296
-      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.40.0/atlantis_linux_arm64.zip
+        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311772
+      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_linux_arm64.zip
         content_type: application/zip
-        created_at: "2026-01-30T05:47:13Z"
-        digest: sha256:a096129e426f78dc9d0343c22b80608b280549d19bb465c384847166839652de
-        download_count: 1
-        id: 348054303
+        created_at: "2026-06-30T16:11:05Z"
+        digest: sha256:45bca36eb2411638dd66aeb3dfff5a19255d8a58f28be3937c6d83bc9c90e327
+        download_count: 40
+        id: 462311746
         label: ""
         name: atlantis_linux_arm64.zip
-        node_id: RA_kwDOBy76Zc4UvuMf
-        size: 11465425
+        node_id: RA_kwDOBy76Zc4bjlFC
+        size: 12994491
         state: uploaded
-        updated_at: "2026-01-30T05:47:14Z"
+        updated_at: "2026-06-30T16:11:06Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -242,19 +243,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/348054303
-      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.40.0/atlantis_windows_386.zip
+        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311746
+      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_windows_386.zip
         content_type: application/zip
-        created_at: "2026-01-30T05:47:13Z"
-        digest: sha256:e397d3e630526dae23a4cd3a370568f6fa69f4e84659ad46c44c5879a030b181
-        download_count: 1
-        id: 348054302
+        created_at: "2026-06-30T16:11:07Z"
+        digest: sha256:d87bfc08e37f9e23cb0ac723f42d91f02d07a2fade545ef736778669b1f12b10
+        download_count: 4
+        id: 462311778
         label: ""
         name: atlantis_windows_386.zip
-        node_id: RA_kwDOBy76Zc4UvuMe
-        size: 12410746
+        node_id: RA_kwDOBy76Zc4bjlFi
+        size: 14108899
         state: uploaded
-        updated_at: "2026-01-30T05:47:15Z"
+        updated_at: "2026-06-30T16:11:08Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -275,19 +276,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/348054302
-      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.40.0/atlantis_windows_amd64.zip
+        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311778
+      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_windows_amd64.zip
         content_type: application/zip
-        created_at: "2026-01-30T05:47:15Z"
-        digest: sha256:9880d757f1f56f9551652a1629ab685325baff8591bcd0d7a41e4ec4daf90ba0
-        download_count: 1
-        id: 348054308
+        created_at: "2026-06-30T16:11:05Z"
+        digest: sha256:016dd8ad1b7f4a0bab3e28feb1edc8c7d3f12c7848379656ba17a70d52b73972
+        download_count: 9
+        id: 462311745
         label: ""
         name: atlantis_windows_amd64.zip
-        node_id: RA_kwDOBy76Zc4UvuMk
-        size: 12979297
+        node_id: RA_kwDOBy76Zc4bjlFB
+        size: 14763688
         state: uploaded
-        updated_at: "2026-01-30T05:47:15Z"
+        updated_at: "2026-06-30T16:11:06Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -308,19 +309,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/348054308
-      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.40.0/checksums.txt
+        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311745
+      - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/checksums.txt
         content_type: text/plain; charset=utf-8
-        created_at: "2026-01-30T05:47:15Z"
-        digest: sha256:38866612f6207926a757e79fe8f7a5618e576054996f862fd3e72150906cdd39
-        download_count: 3
-        id: 348054310
+        created_at: "2026-06-30T16:11:09Z"
+        digest: sha256:0139701deb03c261c2d485ef228350e47f2868d791ac5b5227000f201336d215
+        download_count: 12
+        id: 462311793
         label: ""
         name: checksums.txt
-        node_id: RA_kwDOBy76Zc4UvuMm
+        node_id: RA_kwDOBy76Zc4bjlFx
         size: 728
         state: uploaded
-        updated_at: "2026-01-30T05:47:15Z"
+        updated_at: "2026-06-30T16:11:09Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -341,116 +342,99 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/348054310
-      assets_url: https://api.github.com/repos/runatlantis/atlantis/releases/281375485/assets
+        url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311793
+      assets_url: https://api.github.com/repos/runatlantis/atlantis/releases/346951880/assets
       author:
-        avatar_url: https://avatars.githubusercontent.com/u/2208324?v=4
-        events_url: https://api.github.com/users/jamengual/events{/privacy}
-        followers_url: https://api.github.com/users/jamengual/followers
-        following_url: https://api.github.com/users/jamengual/following{/other_user}
-        gists_url: https://api.github.com/users/jamengual/gists{/gist_id}
+        avatar_url: https://avatars.githubusercontent.com/u/1580956?v=4
+        events_url: https://api.github.com/users/chenrui333/events{/privacy}
+        followers_url: https://api.github.com/users/chenrui333/followers
+        following_url: https://api.github.com/users/chenrui333/following{/other_user}
+        gists_url: https://api.github.com/users/chenrui333/gists{/gist_id}
         gravatar_id: ""
-        html_url: https://github.com/jamengual
-        id: 2208324
-        login: jamengual
-        node_id: MDQ6VXNlcjIyMDgzMjQ=
-        organizations_url: https://api.github.com/users/jamengual/orgs
-        received_events_url: https://api.github.com/users/jamengual/received_events
-        repos_url: https://api.github.com/users/jamengual/repos
+        html_url: https://github.com/chenrui333
+        id: 1580956
+        login: chenrui333
+        node_id: MDQ6VXNlcjE1ODA5NTY=
+        organizations_url: https://api.github.com/users/chenrui333/orgs
+        received_events_url: https://api.github.com/users/chenrui333/received_events
+        repos_url: https://api.github.com/users/chenrui333/repos
         site_admin: false
-        starred_url: https://api.github.com/users/jamengual/starred{/owner}{/repo}
-        subscriptions_url: https://api.github.com/users/jamengual/subscriptions
+        starred_url: https://api.github.com/users/chenrui333/starred{/owner}{/repo}
+        subscriptions_url: https://api.github.com/users/chenrui333/subscriptions
         type: User
-        url: https://api.github.com/users/jamengual
+        url: https://api.github.com/users/chenrui333
         user_view_type: public
-      body: "<!-- Release notes generated using configuration in .github/release.yml
-        at main -->\r\n### The core Atlantis team is preparing for a stable 1.0.0
-        release! Please reach out if you are working on a potentially breaking change
-        that might affect our planning. \U0001F680 \r\n## What's Changed\r\n### Exciting
-        New Features \U0001F389\r\n* fix: Add project name to locking key by @carmennavarreteh
-        in https://github.com/runatlantis/atlantis/pull/6004\r\n### Bug fixes \U0001F41B\r\n*
-        fix: Do not add \"passed_policy\" as a plan or import requirement by @lukemassa
-        in https://github.com/runatlantis/atlantis/pull/6027\r\n* chore: Fallback
-        to force clone on any error attempting repo reuse by @lukemassa in https://github.com/runatlantis/atlantis/pull/6011\r\n*
-        fix: API Controller CommentCommand.Name defaults to Apply instead of Plan
-        by @rjmsilveira in https://github.com/runatlantis/atlantis/pull/6090\r\n###
-        Documentation\r\n* chore(deps): update dependency markdownlint-cli to v0.47.0
-        in package.json (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6059\r\n*
-        fix: Assume divergence until established otherwise by @aggrand in https://github.com/runatlantis/atlantis/pull/5955\r\n*
-        docs(runatlantis.io): Fix typos in documentation files by @hsusanoo in https://github.com/runatlantis/atlantis/pull/6063\r\n*
-        chore(deps): update node.js to v22.21.1 in .node-version (main) by @renovate[bot]
-        in https://github.com/runatlantis/atlantis/pull/6076\r\n* chore(deps): update
-        dependency @types/node to v22.19.5 in package.json (main) by @renovate[bot]
-        in https://github.com/runatlantis/atlantis/pull/6084\r\n* docs: Update API
-        Endpoints params by @albertorm95 in https://github.com/runatlantis/atlantis/pull/6092\r\n*
-        chore(deps): update node.js to v22.22.0 in .node-version (main) by @renovate[bot]
-        in https://github.com/runatlantis/atlantis/pull/6096\r\n* docs: Add alpha
-        API notice to API endpoints documentation by @jamengual in https://github.com/runatlantis/atlantis/pull/6097\r\n*
-        chore(deps): update dependency vue to v3.5.27 in package.json (main) by @renovate[bot]
-        in https://github.com/runatlantis/atlantis/pull/6105\r\n### Dependencies\r\n*
-        chore(deps): update ghcr.io/runatlantis/atlantis:latest docker digest to 9bb5658
-        in dockerfile.dev (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6055\r\n*
-        chore(deps): update debian:12.12-slim docker digest to d5d3f9c in dockerfile
-        (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6057\r\n*
-        chore(deps): update dependency open-policy-agent/conftest to v0.66.0 in dockerfile
-        (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6061\r\n*
-        chore(deps): update dependency open-policy-agent/conftest to v0.66.0 in testing/dockerfile
-        (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6064\r\n*
-        chore(deps): update dependency opentofu/opentofu to v1.11.2 in dockerfile
-        (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6067\r\n*
-        chore(deps): update ngrok/ngrok:latest docker digest to d20e963 in docker-compose.yml
-        (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6082\r\n*
-        chore(deps): update dependency opentofu/opentofu to v1.11.3 in dockerfile
-        (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6089\r\n*
-        chore(deps): update debian docker tag to v12.13 in dockerfile (main) by @renovate[bot]
-        in https://github.com/runatlantis/atlantis/pull/6091\r\n* chore(deps): update
-        terraform random to v3.8.0 in server/controllers/events/testdata/test-repos/state-rm-single-project/versions.tf
-        (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6099\r\n*
-        fix(deps): update module code.gitea.io/sdk/gitea to v0.22.1 in go.mod (main)
-        by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6111\r\n*
-        fix(deps): update github.com/hashicorp/terraform-config-inspect digest to
-        7854796 in go.mod (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6112\r\n###
-        Other Changes \U0001F504\r\n* chore: Add project command output struct by
-        @lukemassa in https://github.com/runatlantis/atlantis/pull/5964\r\n* fix:
-        Add project name to command locking by @carmennavarreteh in https://github.com/runatlantis/atlantis/pull/6086\r\n*
-        chore(deps): manual upgrade to Alpine 3.23 by @Vlaaaaaaad in https://github.com/runatlantis/atlantis/pull/6051\r\n\r\n##
-        New Contributors\r\n* @aggrand made their first contribution in https://github.com/runatlantis/atlantis/pull/5955\r\n*
-        @hsusanoo made their first contribution in https://github.com/runatlantis/atlantis/pull/6063\r\n*
-        @carmennavarreteh made their first contribution in https://github.com/runatlantis/atlantis/pull/6086\r\n*
-        @Vlaaaaaaad made their first contribution in https://github.com/runatlantis/atlantis/pull/6051\r\n\r\n**Full
-        Changelog**: https://github.com/runatlantis/atlantis/compare/v0.39.0...v0.40.0"
-      created_at: "2026-01-30T02:01:51Z"
-      discussion_url: https://github.com/runatlantis/atlantis/discussions/6122
+      body: "## Highlights\n\n- **OpenTofu .tofu support**: Atlantis now detects OpenTofu
+        versions from .tofu and .tofu.json files, includes those files in default
+        autoplan and project discovery behavior, and detects Terraform Cloud/Enterprise
+        workspace configuration from .tf.json, .tofu, and .tofu.json projects.\n-
+        **Broader core workflow coverage**: The E2E harness now activates expanded
+        fixtures from [runatlantis/atlantis-tests#21001](https://github.com/runatlantis/atlantis-tests/pull/21001),
+        covering multi-project targeting, autodiscovery, configured JSON projects,
+        custom workflow environment behavior, and long-output status contexts.\n-
+        **Safer plan/apply behavior**: This release hardens apply validation against
+        stale head/base plan state, preserves on_apply locks during plan cleanup,
+        and fixes /api/plan with policy checks enabled while preserving per-project
+        /api/apply behavior.\n\n## Project Health\n\n- **Top-Ranking Atlantis Issues
+        :bar_chart:** Maintainers and contributors can now use [#6608](https://github.com/runatlantis/atlantis/issues/6608)
+        to see open Atlantis issues ranked by community thumbs-up reactions. The ranking
+        is a signal for prioritization and contribution, not a roadmap commitment
+        or acceptance guarantee.\n- Atlantis now uploads Go coverage to GitHub Code
+        Quality, lints the separate e2e Go module, and has automated top-issue ranking
+        to make maintenance work more visible.\n- We welcome contributors across bug
+        reports, focused fixes, documentation improvements, issue reproduction, and
+        issue moderation/triage.\n\n## Call For Adopters\n\nIf your organization uses
+        Atlantis and can share a sanitized setup or adoption note, [runatlantis/examples](https://github.com/runatlantis/examples)
+        is a good place to contribute it. Public examples help users learn from real
+        deployments, help the project document its ecosystem, and can become future
+        candidates for atlantis-tests fixture coverage.\n\n## What's Next\n\nWe are
+        also looking at flag lifecycle improvements so Atlantis has a clearer path
+        for introducing, documenting, deprecating, and eventually removing server
+        flags.\n\n## What's Changed\n\n### Exciting New Features \U0001F389\n\n* feat(e2e):
+        activate new fixture coverage from atlantis-tests#21001 by @chenrui333 in
+        https://github.com/runatlantis/atlantis/pull/6601\n* feat: support OpenTofu
+        .tofu/.tofu.json version auto-detection by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6600\n*
+        feat: workspace detection for .tofu/.tofu.json, shared project indicators
+        by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6603\n\n###
+        Provider Bitbucket\n\n* fix: validate current head and base plan state by
+        @chenrui333 in https://github.com/runatlantis/atlantis/pull/6605\n\n### Bug
+        fixes \U0001F41B\n\n* fix: preserve on_apply locks during plan cleanup by
+        @chenrui333 in https://github.com/runatlantis/atlantis/pull/6606\n* fix: normalize
+        TestExecute_Flags path assertions by @Atul-Koundal in https://github.com/runatlantis/atlantis/pull/6612\n*
+        fix: POST /api/plan panics when ATLANTIS_ENABLE_POLICY_CHECKS=true by @Abzaek
+        in https://github.com/runatlantis/atlantis/pull/6484\n\n### Dependencies\n\n*
+        chore(deps): update gcr.io/oss-fuzz-base/base-builder-go docker digest to
+        aa0051c in .clusterfuzzlite/dockerfile (main) by @renovate[bot] in https://github.com/runatlantis/atlantis/pull/6607\n\n###
+        Other Changes \U0001F504\n\n* ci(e2e): add lint coverage and harden cleanup
+        safety by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6602\n*
+        ci: upload Go coverage to GitHub Code Quality by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6604\n*
+        ci: add top-ranking issues automation by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6610\n*
+        test: close BoltDB instances in locks controller tests by @Atul-Koundal in
+        https://github.com/runatlantis/atlantis/pull/6611\n* test: add on_apply lock
+        preservation scenario by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6609\n\n##
+        New Contributors\n\n* @Abzaek made their first contribution in https://github.com/runatlantis/atlantis/pull/6484\n\n**Full
+        Changelog**: https://github.com/runatlantis/atlantis/compare/v0.45.0...v0.46.0\n"
+      created_at: "2026-06-30T15:51:25Z"
+      discussion_url: https://github.com/runatlantis/atlantis/discussions/6618
       draft: false
-      html_url: https://github.com/runatlantis/atlantis/releases/tag/v0.40.0
-      id: 281375485
+      html_url: https://github.com/runatlantis/atlantis/releases/tag/v0.46.0
+      id: 346951880
       immutable: false
-      mentions_count: 9
-      name: v0.40.0
-      node_id: RE_kwDOBy76Zc4QxXL9
+      mentions_count: 4
+      name: v0.46.0
+      node_id: RE_kwDOBy76Zc4UrhDI
       prerelease: false
-      published_at: "2026-01-30T05:41:38Z"
-      reactions:
-        "+1": 2
-        "-1": 0
-        confused: 0
-        eyes: 0
-        heart: 0
-        hooray: 0
-        laugh: 0
-        rocket: 0
-        total_count: 2
-        url: https://api.github.com/repos/runatlantis/atlantis/releases/281375485/reactions
-      tag_name: v0.40.0
-      tarball_url: https://api.github.com/repos/runatlantis/atlantis/tarball/v0.40.0
-      target_commitish: main
-      updated_at: "2026-01-30T05:47:15Z"
-      upload_url: https://uploads.github.com/repos/runatlantis/atlantis/releases/281375485/assets{?name,label}
-      url: https://api.github.com/repos/runatlantis/atlantis/releases/281375485
-      zipball_url: https://api.github.com/repos/runatlantis/atlantis/zipball/v0.40.0
+      published_at: "2026-06-30T16:04:12Z"
+      tag_name: v0.46.0
+      tarball_url: https://api.github.com/repos/runatlantis/atlantis/tarball/v0.46.0
+      target_commitish: ac39085b350fdfbafb7def905c2f24607fb89b8f
+      updated_at: "2026-06-30T16:11:09Z"
+      upload_url: https://uploads.github.com/repos/runatlantis/atlantis/releases/346951880/assets{?name,label}
+      url: https://api.github.com/repos/runatlantis/atlantis/releases/346951880
+      zipball_url: https://api.github.com/repos/runatlantis/atlantis/zipball/v0.46.0
   awscli:
-    version: 2.34.15
-    previousVersion: 2.34.14
+    version: 2.34.49
+    previousVersion: 2.34.15
     versions:
     - 2.8.2
     - 2.8.3
@@ -1035,9 +1019,10 @@ dependencies:
     - 2.34.13
     - 2.34.14
     - 2.34.15
+    - 2.34.49
   conftest:
-    version: 0.67.0
-    previousVersion: 0.66.0
+    version: 0.68.2
+    previousVersion: 0.67.0
     versions:
     - 0.34.0
     - 0.35.0
@@ -1080,20 +1065,21 @@ dependencies:
     - 0.65.0
     - 0.66.0
     - 0.67.0
+    - 0.68.2
     githubRelease:
       assets:
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/checksums.txt
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/checksums.txt
         content_type: text/plain; charset=utf-8
-        created_at: "2026-03-13T23:41:05Z"
-        digest: sha256:44fbaf71f9a64126b30a3fc8c85bd6d8018a184f7534014e8154b40ec0c61ada
-        download_count: 27
-        id: 373445368
+        created_at: "2026-04-15T05:52:14Z"
+        digest: sha256:08026fd5858d1c08556b50d5a43a8deb03d00b617d46f073a5528910ac0a3e46
+        download_count: 85549
+        id: 396775451
         label: ""
         name: checksums.txt
-        node_id: RA_kwDOCp_e9c4WQlL4
-        size: 1601
+        node_id: RA_kwDOCp_e9c4XplAb
+        size: 1603
         state: uploaded
-        updated_at: "2026-03-13T23:41:06Z"
+        updated_at: "2026-04-15T05:52:14Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1114,19 +1100,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445368
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Darwin_arm64.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775451
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Darwin_arm64.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:00Z"
-        digest: sha256:08fc2672ba56acab8d24ad9b7695340412446a48137af7fd8e61d8db187ad36b
-        download_count: 0
-        id: 373445252
+        created_at: "2026-04-15T05:52:08Z"
+        digest: sha256:cdb5445179e0cc42906e2b0233694900f272a501878d416a9c875b1f7bdfd34c
+        download_count: 3144
+        id: 396775371
         label: ""
-        name: conftest_0.67.0_Darwin_arm64.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKE
-        size: 20492249
+        name: conftest_0.68.2_Darwin_arm64.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_L
+        size: 20564654
         state: uploaded
-        updated_at: "2026-03-13T23:41:01Z"
+        updated_at: "2026-04-15T05:52:09Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1147,19 +1133,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445252
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Darwin_x86_64.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775371
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Darwin_x86_64.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:00Z"
-        digest: sha256:60d42a323918a9f3b17ce562f278974bd97a5a5b311a0145a60a2b2c78e867ba
-        download_count: 0
-        id: 373445251
+        created_at: "2026-04-15T05:52:08Z"
+        digest: sha256:7682c54243d2c16579589f55aac47c51389d26f103f828902880288ba7f0605e
+        download_count: 700
+        id: 396775370
         label: ""
-        name: conftest_0.67.0_Darwin_x86_64.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKD
-        size: 21979364
+        name: conftest_0.68.2_Darwin_x86_64.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_K
+        size: 22058581
         state: uploaded
-        updated_at: "2026-03-13T23:41:02Z"
+        updated_at: "2026-04-15T05:52:09Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1180,19 +1166,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445251
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_amd64.deb
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775370
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.deb
         content_type: application/vnd.debian.binary-package
-        created_at: "2026-03-13T23:41:04Z"
-        digest: sha256:8e04eab7fcc5e4ae7b24fedf7e62e298b119db68f9e91a356be5525922fd4592
-        download_count: 0
-        id: 373445316
+        created_at: "2026-04-15T05:52:11Z"
+        digest: sha256:e08650508022f73c414bc5750bd247e3b3f922cc412345faec70c869b1b2d60e
+        download_count: 160
+        id: 396775414
         label: ""
-        name: conftest_0.67.0_linux_amd64.deb
-        node_id: RA_kwDOCp_e9c4WQlLE
-        size: 21480298
+        name: conftest_0.68.2_Linux_arm64.deb
+        node_id: RA_kwDOCp_e9c4Xpk_2
+        size: 19425190
         state: uploaded
-        updated_at: "2026-03-13T23:41:05Z"
+        updated_at: "2026-04-15T05:52:13Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1213,19 +1199,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445316
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_amd64.rpm
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775414
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.rpm
         content_type: application/x-rpm
-        created_at: "2026-03-13T23:41:03Z"
-        digest: sha256:39911c9523ee1a3d265f04bb898cc4fea04b4151d0872d8f77ce2461961d351c
-        download_count: 0
-        id: 373445292
+        created_at: "2026-04-15T05:52:13Z"
+        digest: sha256:be183450aaa6a8c79b659a5196549ab77bba42be6553009e70a8855dbbf9bb3c
+        download_count: 129
+        id: 396775442
         label: ""
-        name: conftest_0.67.0_linux_amd64.rpm
-        node_id: RA_kwDOCp_e9c4WQlKs
-        size: 22334046
+        name: conftest_0.68.2_Linux_arm64.rpm
+        node_id: RA_kwDOCp_e9c4XplAS
+        size: 19363243
         state: uploaded
-        updated_at: "2026-03-13T23:41:04Z"
+        updated_at: "2026-04-15T05:52:14Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1246,19 +1232,52 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445292
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_arm64.deb
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775442
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.tar.gz
+        content_type: application/gzip
+        created_at: "2026-04-15T05:52:10Z"
+        digest: sha256:4005441089655ded475384cb87d57762ae08ebef78305bada49c70530d2f4184
+        download_count: 33124
+        id: 396775404
+        label: ""
+        name: conftest_0.68.2_Linux_arm64.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_s
+        size: 19424815
+        state: uploaded
+        updated_at: "2026-04-15T05:52:11Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+          user_view_type: public
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775404
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.deb
         content_type: application/vnd.debian.binary-package
-        created_at: "2026-03-13T23:41:03Z"
-        digest: sha256:b4e5ddb677e33d403b7eb74f3d974bbcfcbeff50309c4f7f9b08b4b99ec1e05f
-        download_count: 0
-        id: 373445290
+        created_at: "2026-04-15T05:52:11Z"
+        digest: sha256:46b988cc4ae69291559f9de1aa06b115c5e6c3389656febbe880d8a0d9cb978b
+        download_count: 123
+        id: 396775413
         label: ""
-        name: conftest_0.67.0_linux_arm64.deb
-        node_id: RA_kwDOCp_e9c4WQlKq
-        size: 19443702
+        name: conftest_0.68.2_Linux_ppc64le.deb
+        node_id: RA_kwDOCp_e9c4Xpk_1
+        size: 19348466
         state: uploaded
-        updated_at: "2026-03-13T23:41:04Z"
+        updated_at: "2026-04-15T05:52:12Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1279,19 +1298,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445290
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_arm64.rpm
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775413
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.rpm
         content_type: application/x-rpm
-        created_at: "2026-03-13T23:41:03Z"
-        digest: sha256:f6893a25a2b277fdecf39a333854af92d20c1f34fdb19830f71b701958df3752
-        download_count: 0
-        id: 373445295
+        created_at: "2026-04-15T05:52:13Z"
+        digest: sha256:021d26bc4946486666efa06499ba78fcf792051170c7fe3456e526b46134c2f1
+        download_count: 123
+        id: 396775445
         label: ""
-        name: conftest_0.67.0_linux_arm64.rpm
-        node_id: RA_kwDOCp_e9c4WQlKv
-        size: 20130871
+        name: conftest_0.68.2_Linux_ppc64le.rpm
+        node_id: RA_kwDOCp_e9c4XplAV
+        size: 19272302
         state: uploaded
-        updated_at: "2026-03-13T23:41:04Z"
+        updated_at: "2026-04-15T05:52:15Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1312,19 +1331,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445295
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Linux_arm64.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775445
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:02Z"
-        digest: sha256:bdfd05e17ef899689d02bdf8b9dc1744d3da8053a952c5d67abd8a503881a54a
-        download_count: 0
-        id: 373445268
+        created_at: "2026-04-15T05:52:08Z"
+        digest: sha256:2814b9560329152d1881f3eada73c15b8becf04cdae24367dd057f3d45da1c15
+        download_count: 125
+        id: 396775373
         label: ""
-        name: conftest_0.67.0_Linux_arm64.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKU
-        size: 19353404
+        name: conftest_0.68.2_Linux_ppc64le.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_N
+        size: 19349011
         state: uploaded
-        updated_at: "2026-03-13T23:41:03Z"
+        updated_at: "2026-04-15T05:52:09Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1345,19 +1364,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445268
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_ppc64le.deb
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775373
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.deb
         content_type: application/vnd.debian.binary-package
-        created_at: "2026-03-13T23:41:03Z"
-        digest: sha256:55286b502a137e4a57d1be362a3f197e2033e65a591fa37158bf08ea6fd014cf
-        download_count: 0
-        id: 373445291
+        created_at: "2026-04-15T05:52:12Z"
+        digest: sha256:b8df5aeffe300b114c7fc91ccc3f05b03ea618805dd67f1e2e6bfea4cb0f4f82
+        download_count: 10
+        id: 396775419
         label: ""
-        name: conftest_0.67.0_linux_ppc64le.deb
-        node_id: RA_kwDOCp_e9c4WQlKr
-        size: 19380496
+        name: conftest_0.68.2_Linux_s390x.deb
+        node_id: RA_kwDOCp_e9c4Xpk_7
+        size: 20718922
         state: uploaded
-        updated_at: "2026-03-13T23:41:04Z"
+        updated_at: "2026-04-15T05:52:13Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1378,19 +1397,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445291
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_ppc64le.rpm
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775419
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.rpm
         content_type: application/x-rpm
-        created_at: "2026-03-13T23:41:04Z"
-        digest: sha256:0d5a53b84f13acaf6dee9f1d5c9ab9bb8d373fc1b908733efaa235ae583300b7
-        download_count: 0
-        id: 373445359
+        created_at: "2026-04-15T05:52:12Z"
+        digest: sha256:af6055c52f5e3516c5e370d56ac7bea66fa1ab5ce26ba0a5b9c160144b692a87
+        download_count: 7
+        id: 396775434
         label: ""
-        name: conftest_0.67.0_linux_ppc64le.rpm
-        node_id: RA_kwDOCp_e9c4WQlLv
-        size: 20093522
+        name: conftest_0.68.2_Linux_s390x.rpm
+        node_id: RA_kwDOCp_e9c4XplAK
+        size: 20694819
         state: uploaded
-        updated_at: "2026-03-13T23:41:05Z"
+        updated_at: "2026-04-15T05:52:14Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1411,19 +1430,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445359
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Linux_ppc64le.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775434
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:00Z"
-        digest: sha256:32a53f29afc7d5d4ccb88f3660026bbc26140c716e577407aed853fe7efafbb8
-        download_count: 0
-        id: 373445250
+        created_at: "2026-04-15T05:52:10Z"
+        digest: sha256:5f2651a3097bbaea18df5917753e553efb29738320389cd09bdf87f1a5d67cf9
+        download_count: 10
+        id: 396775408
         label: ""
-        name: conftest_0.67.0_Linux_ppc64le.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKC
-        size: 19275856
+        name: conftest_0.68.2_Linux_s390x.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_w
+        size: 20718607
         state: uploaded
-        updated_at: "2026-03-13T23:41:01Z"
+        updated_at: "2026-04-15T05:52:11Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1444,19 +1463,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445250
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_s390x.deb
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775408
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.deb
         content_type: application/vnd.debian.binary-package
-        created_at: "2026-03-13T23:41:04Z"
-        digest: sha256:9cbd9aac422820e7535a808c574e8770f4467a25f3182b1a98922ec54d2d67dc
-        download_count: 0
-        id: 373445345
+        created_at: "2026-04-15T05:52:12Z"
+        digest: sha256:f2a728e2f6834ee4539d69b0eca7958ef8d632efe81639b5558be70383f272a1
+        download_count: 860
+        id: 396775418
         label: ""
-        name: conftest_0.67.0_linux_s390x.deb
-        node_id: RA_kwDOCp_e9c4WQlLh
-        size: 20793616
+        name: conftest_0.68.2_Linux_x86_64.deb
+        node_id: RA_kwDOCp_e9c4Xpk_6
+        size: 21438484
         state: uploaded
-        updated_at: "2026-03-13T23:41:05Z"
+        updated_at: "2026-04-15T05:52:13Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1477,19 +1496,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445345
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_s390x.rpm
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775418
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.rpm
         content_type: application/x-rpm
-        created_at: "2026-03-13T23:41:05Z"
-        digest: sha256:5e65b4c3fa48259e2837283e00ec805d8ff06b0b35994ff6db623928cc054568
-        download_count: 0
-        id: 373445363
+        created_at: "2026-04-15T05:52:13Z"
+        digest: sha256:26e9914132080e5bad116de61492acff75d0e9d035acf8bad20376d63dc3dbbc
+        download_count: 32950
+        id: 396775444
         label: ""
-        name: conftest_0.67.0_linux_s390x.rpm
-        node_id: RA_kwDOCp_e9c4WQlLz
-        size: 21876355
+        name: conftest_0.68.2_Linux_x86_64.rpm
+        node_id: RA_kwDOCp_e9c4XplAU
+        size: 21420469
         state: uploaded
-        updated_at: "2026-03-13T23:41:06Z"
+        updated_at: "2026-04-15T05:52:15Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1510,19 +1529,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445363
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Linux_s390x.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775444
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:02Z"
-        digest: sha256:99037b6ee40e419d5756794ee5828254a5c1653b6f58e426e9d2e8049c207bdf
-        download_count: 0
-        id: 373445272
+        created_at: "2026-04-15T05:52:08Z"
+        digest: sha256:e8144c6d6d2ae0260b869caa60c7c262a1f95ac63ec1e5d2fb19be452d606347
+        download_count: 864099
+        id: 396775369
         label: ""
-        name: conftest_0.67.0_Linux_s390x.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKY
-        size: 20648328
+        name: conftest_0.68.2_Linux_x86_64.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_J
+        size: 21443091
         state: uploaded
-        updated_at: "2026-03-13T23:41:03Z"
+        updated_at: "2026-04-15T05:52:09Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1543,52 +1562,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445272
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Linux_x86_64.tar.gz
-        content_type: application/gzip
-        created_at: "2026-03-13T23:41:00Z"
-        digest: sha256:a98cfd236f3cadee16d860fbe31cc6edcb0da3efc317f661c7ccd097164b1fdf
-        download_count: 58
-        id: 373445253
-        label: ""
-        name: conftest_0.67.0_Linux_x86_64.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKF
-        size: 21371288
-        state: uploaded
-        updated_at: "2026-03-13T23:41:01Z"
-        uploader:
-          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
-          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
-          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
-          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
-          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
-          gravatar_id: ""
-          html_url: https://github.com/apps/github-actions
-          id: 41898282
-          login: github-actions[bot]
-          node_id: MDM6Qm90NDE4OTgyODI=
-          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
-          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
-          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
-          site_admin: false
-          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
-          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
-          type: Bot
-          url: https://api.github.com/users/github-actions%5Bbot%5D
-          user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445253
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Windows_arm64.zip
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775369
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Windows_arm64.zip
         content_type: application/zip
-        created_at: "2026-03-13T23:41:02Z"
-        digest: sha256:2990aa98320f9b2700b8dc5cbd20f368d95e131916a48f1721bc976c97704900
-        download_count: 0
-        id: 373445269
+        created_at: "2026-04-15T05:52:10Z"
+        digest: sha256:d727e11a9b6fe05ae87c0261aeee7e59ca8be718d80cb7bf6c57206d1523823d
+        download_count: 153
+        id: 396775402
         label: ""
-        name: conftest_0.67.0_Windows_arm64.zip
-        node_id: RA_kwDOCp_e9c4WQlKV
-        size: 19515947
+        name: conftest_0.68.2_Windows_arm64.zip
+        node_id: RA_kwDOCp_e9c4Xpk_q
+        size: 19587060
         state: uploaded
-        updated_at: "2026-03-13T23:41:03Z"
+        updated_at: "2026-04-15T05:52:11Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1609,19 +1595,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445269
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Windows_x86_64.zip
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775402
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Windows_x86_64.zip
         content_type: application/zip
-        created_at: "2026-03-13T23:41:02Z"
-        digest: sha256:5ef4018189e4bd789cded334586732584ca2936bb51791d64dc9317672363826
-        download_count: 0
-        id: 373445271
+        created_at: "2026-04-15T05:52:10Z"
+        digest: sha256:66a88d02e6c03a714e9f0751c3d86ee9c5591739c367ca1b79c4f9f2f90ac4cb
+        download_count: 5466
+        id: 396775403
         label: ""
-        name: conftest_0.67.0_Windows_x86_64.zip
-        node_id: RA_kwDOCp_e9c4WQlKX
-        size: 21907428
+        name: conftest_0.68.2_Windows_x86_64.zip
+        node_id: RA_kwDOCp_e9c4Xpk_r
+        size: 21987095
         state: uploaded
-        updated_at: "2026-03-13T23:41:03Z"
+        updated_at: "2026-04-15T05:52:11Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1642,8 +1628,8 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445271
-      assets_url: https://api.github.com/repos/open-policy-agent/conftest/releases/296915527/assets
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775403
+      assets_url: https://api.github.com/repos/open-policy-agent/conftest/releases/309170097/assets
       author:
         avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
         events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -1666,50 +1652,28 @@ dependencies:
         user_view_type: public
       body: |+
         ## Changelog
-        ### Bug Fixes
-        * 69f41ed9d94c2a0cf6f550bc6849a9853415ded2: fix(plugin): Handle spaces in the plugin command path (#1242) (@jalseth)
         ### OPA Changes
-        * 59cb41900a355f3a58938ebd03314a5eaf1d6b17: build(deps): bump github.com/open-policy-agent/opa from 1.12.1 to 1.13.1 (#1262) (@dependabot[bot])
-        * 507345fcd40d28d1e96674f37f68f7c20ae54fec: build(deps): bump github.com/open-policy-agent/opa from 1.13.1 to 1.13.2 (#1274) (@dependabot[bot])
-        * 69b732911dc60db95e8c90c3c1034103667d9afd: build(deps): bump github.com/open-policy-agent/opa from 1.13.2 to 1.14.1 (#1282) (@dependabot[bot])
+        * 36f23bf930b808c73c4e41c6a4eeac5b620b2225: build(deps): bump github.com/open-policy-agent/opa from 1.15.1 to 1.15.2 (#1311) (@dependabot[bot])
         ### Other Changes
-        * 8ec8ba0b69ec78bc4a9d4414e390470a366aae4b: build(deps): bump actions/checkout from 5.0.0 to 6.0.1 (#1230) (@dependabot[bot])
-        * fb1d20ef7543094c4fd3141bc2db9d6d57b6c78b: build(deps): bump alpine from 3.23.2 to 3.23.3 (#1264) (@dependabot[bot])
-        * 84ee4f1d9f0c83accff72364425ec0c1499ff86c: build(deps): bump bats-core/bats-action from 3.0.1 to 4.0.0 (#1270) (@dependabot[bot])
-        * 06f26a62ea85827b8514f8ecb8f59e4833eec00b: build(deps): bump cuelang.org/go from 0.15.1 to 0.15.3 (#1244) (@dependabot[bot])
-        * d01f783589a2933cca99ea2f740096b0767cfa73: build(deps): bump cuelang.org/go from 0.15.3 to 0.15.4 (#1259) (@dependabot[bot])
-        * b7f9627bacbd002d27125731eb9d75a4ca61a9a6: build(deps): bump cuelang.org/go from 0.15.4 to 0.16.0 (#1279) (@dependabot[bot])
-        * 3e4cf9803baf87b3ad0c6e450c01ad4b38c64cc5: build(deps): bump docker/build-push-action from 6.18.0 to 6.19.2 (#1273) (@dependabot[bot])
-        * b7060d3a09365665856f1152015fecad62a6db0b: build(deps): bump github.com/CycloneDX/cyclonedx-go from 0.9.3 to 0.10.0 (#1265) (@dependabot[bot])
-        * e1305130503c0bf1accea6637a006723d422d8dc: build(deps): bump github.com/hashicorp/go-getter from 1.8.3 to 1.8.4 (#1245) (@dependabot[bot])
-        * e5afd3f7e0473a1dab2723159e1bee8ee93bf125: build(deps): bump github.com/hashicorp/go-getter from 1.8.4 to 1.8.5 (#1285) (@dependabot[bot])
-        * d6f5fb22eee63b2938fe96ad30b91802ddaabbea: build(deps): bump github.com/moby/buildkit from 0.26.3 to 0.27.1 (#1260) (@dependabot[bot])
-        * c1ba80692d46b0c03894b97f61648679c98baad1: build(deps): bump github.com/moby/buildkit from 0.27.1 to 0.28.0 (#1280) (@dependabot[bot])
-        * fc5799680f4c2f4b205f4c60d5475b766e440096: build(deps): bump github.com/spdx/tools-golang from 0.5.5 to 0.5.6 (#1243) (@dependabot[bot])
-        * 95d756f10bde86670351a908f39fdc0f940211c2: build(deps): bump github.com/spdx/tools-golang from 0.5.6 to 0.5.7 (#1251) (@dependabot[bot])
-        * a59b8bdefe3f27d45cc3495ee39983849ccd4bc6: build(deps): bump golang from 1.25.5-alpine to 1.25.6-alpine (#1256) (@dependabot[bot])
-        * bde1457c82e9774f1abd23e35f2e4ac1566d7cbe: build(deps): bump golang from 1.25.6-alpine to 1.26.1-alpine (#1281) (@dependabot[bot])
-        * b2e58f0af6e4ec1738aeb282bc8aa1a5b2e44a94: build(deps): bump golangci/golangci-lint-action from 8.0.0 to 9.2.0 (#1231) (@dependabot[bot])
-        * b1e9f30f47c39c793b6950f3fff065675e939ec7: ci: Update Dependabot config (#1267) (@jalseth)
-        * bf63002f44b5ae9b1caf4c48726bf7cd36efbd1c: ci: Update setup-go to use Go version from go.mod (#1268) (@jalseth)
+        * 479de13f22cbf3b776839591c1f46278d81d2573: build(deps): bump github.com/hashicorp/go-getter from 1.8.5 to 1.8.6 (#1307) (@dependabot[bot])
 
-      created_at: "2026-03-13T22:47:55Z"
+      created_at: "2026-04-15T05:14:00Z"
       draft: false
-      html_url: https://github.com/open-policy-agent/conftest/releases/tag/v0.67.0
-      id: 296915527
+      html_url: https://github.com/open-policy-agent/conftest/releases/tag/v0.68.2
+      id: 309170097
       immutable: false
-      mentions_count: 2
-      name: v0.67.0
-      node_id: RE_kwDOCp_e9c4RspJH
+      mentions_count: 1
+      name: v0.68.2
+      node_id: RE_kwDOCp_e9c4SbY-x
       prerelease: false
-      published_at: "2026-03-13T23:41:06Z"
-      tag_name: v0.67.0
-      tarball_url: https://api.github.com/repos/open-policy-agent/conftest/tarball/v0.67.0
+      published_at: "2026-04-15T05:52:15Z"
+      tag_name: v0.68.2
+      tarball_url: https://api.github.com/repos/open-policy-agent/conftest/tarball/v0.68.2
       target_commitish: master
-      updated_at: "2026-03-13T23:41:06Z"
-      upload_url: https://uploads.github.com/repos/open-policy-agent/conftest/releases/296915527/assets{?name,label}
-      url: https://api.github.com/repos/open-policy-agent/conftest/releases/296915527
-      zipball_url: https://api.github.com/repos/open-policy-agent/conftest/zipball/v0.67.0
+      updated_at: "2026-04-15T05:52:15Z"
+      upload_url: https://uploads.github.com/repos/open-policy-agent/conftest/releases/309170097/assets{?name,label}
+      url: https://api.github.com/repos/open-policy-agent/conftest/releases/309170097
+      zipball_url: https://api.github.com/repos/open-policy-agent/conftest/zipball/v0.68.2
   git_lfs:
     version: 3.7.1
     previousVersion: 3.7.0
@@ -3136,8 +3100,8 @@ dependencies:
       url: https://api.github.com/repos/tianon/gosu/releases/249453666
       zipball_url: https://api.github.com/repos/tianon/gosu/zipball/1.19
   terraform:
-    version: 1.14.7
-    previousVersion: 1.14.6
+    version: 1.15.7
+    previousVersion: 1.14.7
     versions:
     - 1.3.2
     - 1.3.3
@@ -3216,9 +3180,10 @@ dependencies:
     - 1.14.5
     - 1.14.6
     - 1.14.7
+    - 1.15.7
     githubRelease:
       assets: []
-      assets_url: https://api.github.com/repos/hashicorp/terraform/releases/295683027/assets
+      assets_url: https://api.github.com/repos/hashicorp/terraform/releases/344246883/assets
       author:
         avatar_url: https://avatars.githubusercontent.com/u/82989873?v=4
         events_url: https://api.github.com/users/hc-github-team-es-release-engineering/events{/privacy}
@@ -3240,30 +3205,43 @@ dependencies:
         url: https://api.github.com/users/hc-github-team-es-release-engineering
         user_view_type: public
       body: |+
-        ## 1.14.7 (March 11, 2026)
+        ## 1.15.7 (June 24, 2026)
 
 
-        NOTES:
+        BUG FIXES:
 
-        * Bump Go version to 1.25.8 to suppress security scanner false positives ([#38249](https://github.com/hashicorp/terraform/issues/38249))
+        * Add concurrency safety to configs.Parser and SourceBundleParser ([#38745](https://github.com/hashicorp/terraform/issues/38745))
+
+        * Fix submodule variable validation during init ([#38770](https://github.com/hashicorp/terraform/issues/38770))
 
 
-      created_at: "2026-03-11T13:19:07Z"
+      created_at: "2026-06-24T15:51:14Z"
       draft: false
-      html_url: https://github.com/hashicorp/terraform/releases/tag/v1.14.7
-      id: 295683027
+      html_url: https://github.com/hashicorp/terraform/releases/tag/v1.15.7
+      id: 344246883
       immutable: false
-      name: v1.14.7
-      node_id: RE_kwDOAQ6CpM4Rn8PT
+      name: v1.15.7
+      node_id: RE_kwDOAQ6CpM4UhMpj
       prerelease: false
-      published_at: "2026-03-11T14:14:31Z"
-      tag_name: v1.14.7
-      tarball_url: https://api.github.com/repos/hashicorp/terraform/tarball/v1.14.7
-      target_commitish: c0fcd5b52b08f607fbd1e2f164b323f7523146c9
-      updated_at: "2026-03-11T14:14:31Z"
-      upload_url: https://uploads.github.com/repos/hashicorp/terraform/releases/295683027/assets{?name,label}
-      url: https://api.github.com/repos/hashicorp/terraform/releases/295683027
-      zipball_url: https://api.github.com/repos/hashicorp/terraform/zipball/v1.14.7
+      published_at: "2026-06-24T16:47:12Z"
+      reactions:
+        "+1": 0
+        "-1": 0
+        confused: 0
+        eyes: 0
+        heart: 3
+        hooray: 0
+        laugh: 0
+        rocket: 0
+        total_count: 3
+        url: https://api.github.com/repos/hashicorp/terraform/releases/344246883/reactions
+      tag_name: v1.15.7
+      tarball_url: https://api.github.com/repos/hashicorp/terraform/tarball/v1.15.7
+      target_commitish: 214239d0a88cefc3919e79805c5ddd42b922af56
+      updated_at: "2026-06-24T16:47:12Z"
+      upload_url: https://uploads.github.com/repos/hashicorp/terraform/releases/344246883/assets{?name,label}
+      url: https://api.github.com/repos/hashicorp/terraform/releases/344246883
+      zipball_url: https://api.github.com/repos/hashicorp/terraform/zipball/v1.15.7
 meta:
   dependencies:
     atlantis:
@@ -18063,6 +18041,397 @@ meta:
           upload_url: https://uploads.github.com/repos/runatlantis/atlantis/releases/281375485/assets{?name,label}
           url: https://api.github.com/repos/runatlantis/atlantis/releases/281375485
           zipball_url: https://api.github.com/repos/runatlantis/atlantis/zipball/v0.40.0
+      0.46.0:
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_darwin_amd64.zip
+            content_type: application/zip
+            created_at: "2026-06-30T16:11:07Z"
+            digest: sha256:bb07800649c411e3de561af89fecc128c448a72569de542bae8c208f262120aa
+            download_count: 16
+            id: 462311780
+            label: ""
+            name: atlantis_darwin_amd64.zip
+            node_id: RA_kwDOBy76Zc4bjlFk
+            size: 14756418
+            state: uploaded
+            updated_at: "2026-06-30T16:11:08Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311780
+          - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_darwin_arm64.zip
+            content_type: application/zip
+            created_at: "2026-06-30T16:11:07Z"
+            digest: sha256:b5c176d90b03c9d11123b047b61129e0ca77c3ba3cf97f5fb51e2faeb2e84ed3
+            download_count: 20
+            id: 462311783
+            label: ""
+            name: atlantis_darwin_arm64.zip
+            node_id: RA_kwDOBy76Zc4bjlFn
+            size: 13666416
+            state: uploaded
+            updated_at: "2026-06-30T16:11:08Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311783
+          - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_linux_386.zip
+            content_type: application/zip
+            created_at: "2026-06-30T16:11:05Z"
+            digest: sha256:89857be16cb5627bf5f8dd4b5eb1c94c05ab4b39653303aea37ef09539b117df
+            download_count: 2
+            id: 462311743
+            label: ""
+            name: atlantis_linux_386.zip
+            node_id: RA_kwDOBy76Zc4bjlE_
+            size: 13517849
+            state: uploaded
+            updated_at: "2026-06-30T16:11:07Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311743
+          - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_linux_amd64.zip
+            content_type: application/zip
+            created_at: "2026-06-30T16:11:05Z"
+            digest: sha256:00b04241be663ab0302eaad606149e2c3e11f8413beef9b51d838837839c05be
+            download_count: 167
+            id: 462311748
+            label: ""
+            name: atlantis_linux_amd64.zip
+            node_id: RA_kwDOBy76Zc4bjlFE
+            size: 14401237
+            state: uploaded
+            updated_at: "2026-06-30T16:11:06Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311748
+          - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_linux_arm.zip
+            content_type: application/zip
+            created_at: "2026-06-30T16:11:07Z"
+            digest: sha256:e19ed55172ec13fff5547b7974f63a51d68cc0d441a934178054f602e4e7fcb8
+            download_count: 1
+            id: 462311772
+            label: ""
+            name: atlantis_linux_arm.zip
+            node_id: RA_kwDOBy76Zc4bjlFc
+            size: 13459034
+            state: uploaded
+            updated_at: "2026-06-30T16:11:08Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311772
+          - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_linux_arm64.zip
+            content_type: application/zip
+            created_at: "2026-06-30T16:11:05Z"
+            digest: sha256:45bca36eb2411638dd66aeb3dfff5a19255d8a58f28be3937c6d83bc9c90e327
+            download_count: 40
+            id: 462311746
+            label: ""
+            name: atlantis_linux_arm64.zip
+            node_id: RA_kwDOBy76Zc4bjlFC
+            size: 12994491
+            state: uploaded
+            updated_at: "2026-06-30T16:11:06Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311746
+          - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_windows_386.zip
+            content_type: application/zip
+            created_at: "2026-06-30T16:11:07Z"
+            digest: sha256:d87bfc08e37f9e23cb0ac723f42d91f02d07a2fade545ef736778669b1f12b10
+            download_count: 4
+            id: 462311778
+            label: ""
+            name: atlantis_windows_386.zip
+            node_id: RA_kwDOBy76Zc4bjlFi
+            size: 14108899
+            state: uploaded
+            updated_at: "2026-06-30T16:11:08Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311778
+          - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/atlantis_windows_amd64.zip
+            content_type: application/zip
+            created_at: "2026-06-30T16:11:05Z"
+            digest: sha256:016dd8ad1b7f4a0bab3e28feb1edc8c7d3f12c7848379656ba17a70d52b73972
+            download_count: 9
+            id: 462311745
+            label: ""
+            name: atlantis_windows_amd64.zip
+            node_id: RA_kwDOBy76Zc4bjlFB
+            size: 14763688
+            state: uploaded
+            updated_at: "2026-06-30T16:11:06Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311745
+          - browser_download_url: https://github.com/runatlantis/atlantis/releases/download/v0.46.0/checksums.txt
+            content_type: text/plain; charset=utf-8
+            created_at: "2026-06-30T16:11:09Z"
+            digest: sha256:0139701deb03c261c2d485ef228350e47f2868d791ac5b5227000f201336d215
+            download_count: 12
+            id: 462311793
+            label: ""
+            name: checksums.txt
+            node_id: RA_kwDOBy76Zc4bjlFx
+            size: 728
+            state: uploaded
+            updated_at: "2026-06-30T16:11:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/runatlantis/atlantis/releases/assets/462311793
+          assets_url: https://api.github.com/repos/runatlantis/atlantis/releases/346951880/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/1580956?v=4
+            events_url: https://api.github.com/users/chenrui333/events{/privacy}
+            followers_url: https://api.github.com/users/chenrui333/followers
+            following_url: https://api.github.com/users/chenrui333/following{/other_user}
+            gists_url: https://api.github.com/users/chenrui333/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/chenrui333
+            id: 1580956
+            login: chenrui333
+            node_id: MDQ6VXNlcjE1ODA5NTY=
+            organizations_url: https://api.github.com/users/chenrui333/orgs
+            received_events_url: https://api.github.com/users/chenrui333/received_events
+            repos_url: https://api.github.com/users/chenrui333/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/chenrui333/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/chenrui333/subscriptions
+            type: User
+            url: https://api.github.com/users/chenrui333
+            user_view_type: public
+          body: "## Highlights\n\n- **OpenTofu .tofu support**: Atlantis now detects
+            OpenTofu versions from .tofu and .tofu.json files, includes those files
+            in default autoplan and project discovery behavior, and detects Terraform
+            Cloud/Enterprise workspace configuration from .tf.json, .tofu, and .tofu.json
+            projects.\n- **Broader core workflow coverage**: The E2E harness now activates
+            expanded fixtures from [runatlantis/atlantis-tests#21001](https://github.com/runatlantis/atlantis-tests/pull/21001),
+            covering multi-project targeting, autodiscovery, configured JSON projects,
+            custom workflow environment behavior, and long-output status contexts.\n-
+            **Safer plan/apply behavior**: This release hardens apply validation against
+            stale head/base plan state, preserves on_apply locks during plan cleanup,
+            and fixes /api/plan with policy checks enabled while preserving per-project
+            /api/apply behavior.\n\n## Project Health\n\n- **Top-Ranking Atlantis
+            Issues :bar_chart:** Maintainers and contributors can now use [#6608](https://github.com/runatlantis/atlantis/issues/6608)
+            to see open Atlantis issues ranked by community thumbs-up reactions. The
+            ranking is a signal for prioritization and contribution, not a roadmap
+            commitment or acceptance guarantee.\n- Atlantis now uploads Go coverage
+            to GitHub Code Quality, lints the separate e2e Go module, and has automated
+            top-issue ranking to make maintenance work more visible.\n- We welcome
+            contributors across bug reports, focused fixes, documentation improvements,
+            issue reproduction, and issue moderation/triage.\n\n## Call For Adopters\n\nIf
+            your organization uses Atlantis and can share a sanitized setup or adoption
+            note, [runatlantis/examples](https://github.com/runatlantis/examples)
+            is a good place to contribute it. Public examples help users learn from
+            real deployments, help the project document its ecosystem, and can become
+            future candidates for atlantis-tests fixture coverage.\n\n## What's Next\n\nWe
+            are also looking at flag lifecycle improvements so Atlantis has a clearer
+            path for introducing, documenting, deprecating, and eventually removing
+            server flags.\n\n## What's Changed\n\n### Exciting New Features \U0001F389\n\n*
+            feat(e2e): activate new fixture coverage from atlantis-tests#21001 by
+            @chenrui333 in https://github.com/runatlantis/atlantis/pull/6601\n* feat:
+            support OpenTofu .tofu/.tofu.json version auto-detection by @chenrui333
+            in https://github.com/runatlantis/atlantis/pull/6600\n* feat: workspace
+            detection for .tofu/.tofu.json, shared project indicators by @chenrui333
+            in https://github.com/runatlantis/atlantis/pull/6603\n\n### Provider Bitbucket\n\n*
+            fix: validate current head and base plan state by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6605\n\n###
+            Bug fixes \U0001F41B\n\n* fix: preserve on_apply locks during plan cleanup
+            by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6606\n*
+            fix: normalize TestExecute_Flags path assertions by @Atul-Koundal in https://github.com/runatlantis/atlantis/pull/6612\n*
+            fix: POST /api/plan panics when ATLANTIS_ENABLE_POLICY_CHECKS=true by
+            @Abzaek in https://github.com/runatlantis/atlantis/pull/6484\n\n### Dependencies\n\n*
+            chore(deps): update gcr.io/oss-fuzz-base/base-builder-go docker digest
+            to aa0051c in .clusterfuzzlite/dockerfile (main) by @renovate[bot] in
+            https://github.com/runatlantis/atlantis/pull/6607\n\n### Other Changes
+            \U0001F504\n\n* ci(e2e): add lint coverage and harden cleanup safety by
+            @chenrui333 in https://github.com/runatlantis/atlantis/pull/6602\n* ci:
+            upload Go coverage to GitHub Code Quality by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6604\n*
+            ci: add top-ranking issues automation by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6610\n*
+            test: close BoltDB instances in locks controller tests by @Atul-Koundal
+            in https://github.com/runatlantis/atlantis/pull/6611\n* test: add on_apply
+            lock preservation scenario by @chenrui333 in https://github.com/runatlantis/atlantis/pull/6609\n\n##
+            New Contributors\n\n* @Abzaek made their first contribution in https://github.com/runatlantis/atlantis/pull/6484\n\n**Full
+            Changelog**: https://github.com/runatlantis/atlantis/compare/v0.45.0...v0.46.0\n"
+          created_at: "2026-06-30T15:51:25Z"
+          discussion_url: https://github.com/runatlantis/atlantis/discussions/6618
+          draft: false
+          html_url: https://github.com/runatlantis/atlantis/releases/tag/v0.46.0
+          id: 346951880
+          immutable: false
+          mentions_count: 4
+          name: v0.46.0
+          node_id: RE_kwDOBy76Zc4UrhDI
+          prerelease: false
+          published_at: "2026-06-30T16:04:12Z"
+          tag_name: v0.46.0
+          tarball_url: https://api.github.com/repos/runatlantis/atlantis/tarball/v0.46.0
+          target_commitish: ac39085b350fdfbafb7def905c2f24607fb89b8f
+          updated_at: "2026-06-30T16:11:09Z"
+          upload_url: https://uploads.github.com/repos/runatlantis/atlantis/releases/346951880/assets{?name,label}
+          url: https://api.github.com/repos/runatlantis/atlantis/releases/346951880
+          zipball_url: https://api.github.com/repos/runatlantis/atlantis/zipball/v0.46.0
     conftest:
       0.34.0:
         githubRelease:
@@ -40452,6 +40821,615 @@ meta:
           upload_url: https://uploads.github.com/repos/open-policy-agent/conftest/releases/296915527/assets{?name,label}
           url: https://api.github.com/repos/open-policy-agent/conftest/releases/296915527
           zipball_url: https://api.github.com/repos/open-policy-agent/conftest/zipball/v0.67.0
+      0.68.2:
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/checksums.txt
+            content_type: text/plain; charset=utf-8
+            created_at: "2026-04-15T05:52:14Z"
+            digest: sha256:08026fd5858d1c08556b50d5a43a8deb03d00b617d46f073a5528910ac0a3e46
+            download_count: 85549
+            id: 396775451
+            label: ""
+            name: checksums.txt
+            node_id: RA_kwDOCp_e9c4XplAb
+            size: 1603
+            state: uploaded
+            updated_at: "2026-04-15T05:52:14Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775451
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Darwin_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:08Z"
+            digest: sha256:cdb5445179e0cc42906e2b0233694900f272a501878d416a9c875b1f7bdfd34c
+            download_count: 3144
+            id: 396775371
+            label: ""
+            name: conftest_0.68.2_Darwin_arm64.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_L
+            size: 20564654
+            state: uploaded
+            updated_at: "2026-04-15T05:52:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775371
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Darwin_x86_64.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:08Z"
+            digest: sha256:7682c54243d2c16579589f55aac47c51389d26f103f828902880288ba7f0605e
+            download_count: 700
+            id: 396775370
+            label: ""
+            name: conftest_0.68.2_Darwin_x86_64.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_K
+            size: 22058581
+            state: uploaded
+            updated_at: "2026-04-15T05:52:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775370
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.deb
+            content_type: application/vnd.debian.binary-package
+            created_at: "2026-04-15T05:52:11Z"
+            digest: sha256:e08650508022f73c414bc5750bd247e3b3f922cc412345faec70c869b1b2d60e
+            download_count: 160
+            id: 396775414
+            label: ""
+            name: conftest_0.68.2_Linux_arm64.deb
+            node_id: RA_kwDOCp_e9c4Xpk_2
+            size: 19425190
+            state: uploaded
+            updated_at: "2026-04-15T05:52:13Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775414
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.rpm
+            content_type: application/x-rpm
+            created_at: "2026-04-15T05:52:13Z"
+            digest: sha256:be183450aaa6a8c79b659a5196549ab77bba42be6553009e70a8855dbbf9bb3c
+            download_count: 129
+            id: 396775442
+            label: ""
+            name: conftest_0.68.2_Linux_arm64.rpm
+            node_id: RA_kwDOCp_e9c4XplAS
+            size: 19363243
+            state: uploaded
+            updated_at: "2026-04-15T05:52:14Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775442
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:10Z"
+            digest: sha256:4005441089655ded475384cb87d57762ae08ebef78305bada49c70530d2f4184
+            download_count: 33124
+            id: 396775404
+            label: ""
+            name: conftest_0.68.2_Linux_arm64.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_s
+            size: 19424815
+            state: uploaded
+            updated_at: "2026-04-15T05:52:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775404
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.deb
+            content_type: application/vnd.debian.binary-package
+            created_at: "2026-04-15T05:52:11Z"
+            digest: sha256:46b988cc4ae69291559f9de1aa06b115c5e6c3389656febbe880d8a0d9cb978b
+            download_count: 123
+            id: 396775413
+            label: ""
+            name: conftest_0.68.2_Linux_ppc64le.deb
+            node_id: RA_kwDOCp_e9c4Xpk_1
+            size: 19348466
+            state: uploaded
+            updated_at: "2026-04-15T05:52:12Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775413
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.rpm
+            content_type: application/x-rpm
+            created_at: "2026-04-15T05:52:13Z"
+            digest: sha256:021d26bc4946486666efa06499ba78fcf792051170c7fe3456e526b46134c2f1
+            download_count: 123
+            id: 396775445
+            label: ""
+            name: conftest_0.68.2_Linux_ppc64le.rpm
+            node_id: RA_kwDOCp_e9c4XplAV
+            size: 19272302
+            state: uploaded
+            updated_at: "2026-04-15T05:52:15Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775445
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:08Z"
+            digest: sha256:2814b9560329152d1881f3eada73c15b8becf04cdae24367dd057f3d45da1c15
+            download_count: 125
+            id: 396775373
+            label: ""
+            name: conftest_0.68.2_Linux_ppc64le.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_N
+            size: 19349011
+            state: uploaded
+            updated_at: "2026-04-15T05:52:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775373
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.deb
+            content_type: application/vnd.debian.binary-package
+            created_at: "2026-04-15T05:52:12Z"
+            digest: sha256:b8df5aeffe300b114c7fc91ccc3f05b03ea618805dd67f1e2e6bfea4cb0f4f82
+            download_count: 10
+            id: 396775419
+            label: ""
+            name: conftest_0.68.2_Linux_s390x.deb
+            node_id: RA_kwDOCp_e9c4Xpk_7
+            size: 20718922
+            state: uploaded
+            updated_at: "2026-04-15T05:52:13Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775419
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.rpm
+            content_type: application/x-rpm
+            created_at: "2026-04-15T05:52:12Z"
+            digest: sha256:af6055c52f5e3516c5e370d56ac7bea66fa1ab5ce26ba0a5b9c160144b692a87
+            download_count: 7
+            id: 396775434
+            label: ""
+            name: conftest_0.68.2_Linux_s390x.rpm
+            node_id: RA_kwDOCp_e9c4XplAK
+            size: 20694819
+            state: uploaded
+            updated_at: "2026-04-15T05:52:14Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775434
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:10Z"
+            digest: sha256:5f2651a3097bbaea18df5917753e553efb29738320389cd09bdf87f1a5d67cf9
+            download_count: 10
+            id: 396775408
+            label: ""
+            name: conftest_0.68.2_Linux_s390x.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_w
+            size: 20718607
+            state: uploaded
+            updated_at: "2026-04-15T05:52:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775408
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.deb
+            content_type: application/vnd.debian.binary-package
+            created_at: "2026-04-15T05:52:12Z"
+            digest: sha256:f2a728e2f6834ee4539d69b0eca7958ef8d632efe81639b5558be70383f272a1
+            download_count: 860
+            id: 396775418
+            label: ""
+            name: conftest_0.68.2_Linux_x86_64.deb
+            node_id: RA_kwDOCp_e9c4Xpk_6
+            size: 21438484
+            state: uploaded
+            updated_at: "2026-04-15T05:52:13Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775418
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.rpm
+            content_type: application/x-rpm
+            created_at: "2026-04-15T05:52:13Z"
+            digest: sha256:26e9914132080e5bad116de61492acff75d0e9d035acf8bad20376d63dc3dbbc
+            download_count: 32950
+            id: 396775444
+            label: ""
+            name: conftest_0.68.2_Linux_x86_64.rpm
+            node_id: RA_kwDOCp_e9c4XplAU
+            size: 21420469
+            state: uploaded
+            updated_at: "2026-04-15T05:52:15Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775444
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:08Z"
+            digest: sha256:e8144c6d6d2ae0260b869caa60c7c262a1f95ac63ec1e5d2fb19be452d606347
+            download_count: 864099
+            id: 396775369
+            label: ""
+            name: conftest_0.68.2_Linux_x86_64.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_J
+            size: 21443091
+            state: uploaded
+            updated_at: "2026-04-15T05:52:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775369
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Windows_arm64.zip
+            content_type: application/zip
+            created_at: "2026-04-15T05:52:10Z"
+            digest: sha256:d727e11a9b6fe05ae87c0261aeee7e59ca8be718d80cb7bf6c57206d1523823d
+            download_count: 153
+            id: 396775402
+            label: ""
+            name: conftest_0.68.2_Windows_arm64.zip
+            node_id: RA_kwDOCp_e9c4Xpk_q
+            size: 19587060
+            state: uploaded
+            updated_at: "2026-04-15T05:52:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775402
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Windows_x86_64.zip
+            content_type: application/zip
+            created_at: "2026-04-15T05:52:10Z"
+            digest: sha256:66a88d02e6c03a714e9f0751c3d86ee9c5591739c367ca1b79c4f9f2f90ac4cb
+            download_count: 5466
+            id: 396775403
+            label: ""
+            name: conftest_0.68.2_Windows_x86_64.zip
+            node_id: RA_kwDOCp_e9c4Xpk_r
+            size: 21987095
+            state: uploaded
+            updated_at: "2026-04-15T05:52:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775403
+          assets_url: https://api.github.com/repos/open-policy-agent/conftest/releases/309170097/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+            events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+            followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+            following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+            gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/apps/github-actions
+            id: 41898282
+            login: github-actions[bot]
+            node_id: MDM6Qm90NDE4OTgyODI=
+            organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+            received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+            repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+            type: Bot
+            url: https://api.github.com/users/github-actions%5Bbot%5D
+            user_view_type: public
+          body: |+
+            ## Changelog
+            ### OPA Changes
+            * 36f23bf930b808c73c4e41c6a4eeac5b620b2225: build(deps): bump github.com/open-policy-agent/opa from 1.15.1 to 1.15.2 (#1311) (@dependabot[bot])
+            ### Other Changes
+            * 479de13f22cbf3b776839591c1f46278d81d2573: build(deps): bump github.com/hashicorp/go-getter from 1.8.5 to 1.8.6 (#1307) (@dependabot[bot])
+
+          created_at: "2026-04-15T05:14:00Z"
+          draft: false
+          html_url: https://github.com/open-policy-agent/conftest/releases/tag/v0.68.2
+          id: 309170097
+          immutable: false
+          mentions_count: 1
+          name: v0.68.2
+          node_id: RE_kwDOCp_e9c4SbY-x
+          prerelease: false
+          published_at: "2026-04-15T05:52:15Z"
+          tag_name: v0.68.2
+          tarball_url: https://api.github.com/repos/open-policy-agent/conftest/tarball/v0.68.2
+          target_commitish: master
+          updated_at: "2026-04-15T05:52:15Z"
+          upload_url: https://uploads.github.com/repos/open-policy-agent/conftest/releases/309170097/assets{?name,label}
+          url: https://api.github.com/repos/open-policy-agent/conftest/releases/309170097
+          zipball_url: https://api.github.com/repos/open-policy-agent/conftest/zipball/v0.68.2
     git_lfs:
       3.2.0:
         githubRelease:
@@ -55065,3 +56043,65 @@ meta:
           upload_url: https://uploads.github.com/repos/hashicorp/terraform/releases/295683027/assets{?name,label}
           url: https://api.github.com/repos/hashicorp/terraform/releases/295683027
           zipball_url: https://api.github.com/repos/hashicorp/terraform/zipball/v1.14.7
+      1.15.7:
+        githubRelease:
+          assets: []
+          assets_url: https://api.github.com/repos/hashicorp/terraform/releases/344246883/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/u/82989873?v=4
+            events_url: https://api.github.com/users/hc-github-team-es-release-engineering/events{/privacy}
+            followers_url: https://api.github.com/users/hc-github-team-es-release-engineering/followers
+            following_url: https://api.github.com/users/hc-github-team-es-release-engineering/following{/other_user}
+            gists_url: https://api.github.com/users/hc-github-team-es-release-engineering/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/hc-github-team-es-release-engineering
+            id: 82989873
+            login: hc-github-team-es-release-engineering
+            node_id: MDQ6VXNlcjgyOTg5ODcz
+            organizations_url: https://api.github.com/users/hc-github-team-es-release-engineering/orgs
+            received_events_url: https://api.github.com/users/hc-github-team-es-release-engineering/received_events
+            repos_url: https://api.github.com/users/hc-github-team-es-release-engineering/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/hc-github-team-es-release-engineering/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/hc-github-team-es-release-engineering/subscriptions
+            type: User
+            url: https://api.github.com/users/hc-github-team-es-release-engineering
+            user_view_type: public
+          body: |+
+            ## 1.15.7 (June 24, 2026)
+
+
+            BUG FIXES:
+
+            * Add concurrency safety to configs.Parser and SourceBundleParser ([#38745](https://github.com/hashicorp/terraform/issues/38745))
+
+            * Fix submodule variable validation during init ([#38770](https://github.com/hashicorp/terraform/issues/38770))
+
+
+          created_at: "2026-06-24T15:51:14Z"
+          draft: false
+          html_url: https://github.com/hashicorp/terraform/releases/tag/v1.15.7
+          id: 344246883
+          immutable: false
+          name: v1.15.7
+          node_id: RE_kwDOAQ6CpM4UhMpj
+          prerelease: false
+          published_at: "2026-06-24T16:47:12Z"
+          reactions:
+            "+1": 0
+            "-1": 0
+            confused: 0
+            eyes: 0
+            heart: 3
+            hooray: 0
+            laugh: 0
+            rocket: 0
+            total_count: 3
+            url: https://api.github.com/repos/hashicorp/terraform/releases/344246883/reactions
+          tag_name: v1.15.7
+          tarball_url: https://api.github.com/repos/hashicorp/terraform/tarball/v1.15.7
+          target_commitish: 214239d0a88cefc3919e79805c5ddd42b922af56
+          updated_at: "2026-06-24T16:47:12Z"
+          upload_url: https://uploads.github.com/repos/hashicorp/terraform/releases/344246883/assets{?name,label}
+          url: https://api.github.com/repos/hashicorp/terraform/releases/344246883
+          zipball_url: https://api.github.com/repos/hashicorp/terraform/zipball/v1.15.7

--- a/conftest/Dockerfile
+++ b/conftest/Dockerfile
@@ -2,16 +2,20 @@ FROM ubuntu:22.04
 
 ARG TARGETARCH
 
-ARG CONFTEST_VERSION=0.67.0
+ARG CONFTEST_VERSION=0.68.2
 LABEL version="${CONFTEST_VERSION}"
 LABEL maintainer="sakamoto@chatwork.com"
-
-ARG CONFTEST_DEP_FILE="conftest_${CONFTEST_VERSION}_linux_${TARGETARCH}.deb"
 
 RUN apt-get update -y && \
     apt-get install -y wget git
 
-RUN wget -q https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/${CONFTEST_DEP_FILE} && \
+RUN case "${TARGETARCH}" in \
+        "amd64") CONFTEST_ARCH=x86_64 ;; \
+        "arm64") CONFTEST_ARCH=arm64 ;; \
+        *) echo "ERROR: 'TARGETARCH' value expected: ${TARGETARCH}"; exit 1 ;; \
+    esac && \
+    CONFTEST_DEP_FILE="conftest_${CONFTEST_VERSION}_Linux_${CONFTEST_ARCH}.deb" && \
+    wget -q https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/${CONFTEST_DEP_FILE} && \
     dpkg -i ./${CONFTEST_DEP_FILE} && \
     rm -f ./${CONFTEST_DEP_FILE} && \
     apt-get clean  && \

--- a/conftest/goss/goss.yaml
+++ b/conftest/goss/goss.yaml
@@ -6,4 +6,4 @@ command:
   /usr/bin/conftest --version:
     exit-status: 0
     stdout:
-      - 0.67.0
+      - 0.68.2

--- a/conftest/variant.lock
+++ b/conftest/variant.lock
@@ -1,7 +1,7 @@
 dependencies:
   conftest:
-    version: 0.67.0
-    previousVersion: 0.66.0
+    version: 0.68.2
+    previousVersion: 0.67.0
     versions:
     - 0.34.0
     - 0.35.0
@@ -44,20 +44,21 @@ dependencies:
     - 0.65.0
     - 0.66.0
     - 0.67.0
+    - 0.68.2
     githubRelease:
       assets:
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/checksums.txt
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/checksums.txt
         content_type: text/plain; charset=utf-8
-        created_at: "2026-03-13T23:41:05Z"
-        digest: sha256:44fbaf71f9a64126b30a3fc8c85bd6d8018a184f7534014e8154b40ec0c61ada
-        download_count: 27
-        id: 373445368
+        created_at: "2026-04-15T05:52:14Z"
+        digest: sha256:08026fd5858d1c08556b50d5a43a8deb03d00b617d46f073a5528910ac0a3e46
+        download_count: 85635
+        id: 396775451
         label: ""
         name: checksums.txt
-        node_id: RA_kwDOCp_e9c4WQlL4
-        size: 1601
+        node_id: RA_kwDOCp_e9c4XplAb
+        size: 1603
         state: uploaded
-        updated_at: "2026-03-13T23:41:06Z"
+        updated_at: "2026-04-15T05:52:14Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -78,19 +79,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445368
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Darwin_arm64.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775451
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Darwin_arm64.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:00Z"
-        digest: sha256:08fc2672ba56acab8d24ad9b7695340412446a48137af7fd8e61d8db187ad36b
-        download_count: 0
-        id: 373445252
+        created_at: "2026-04-15T05:52:08Z"
+        digest: sha256:cdb5445179e0cc42906e2b0233694900f272a501878d416a9c875b1f7bdfd34c
+        download_count: 3144
+        id: 396775371
         label: ""
-        name: conftest_0.67.0_Darwin_arm64.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKE
-        size: 20492249
+        name: conftest_0.68.2_Darwin_arm64.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_L
+        size: 20564654
         state: uploaded
-        updated_at: "2026-03-13T23:41:01Z"
+        updated_at: "2026-04-15T05:52:09Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -111,19 +112,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445252
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Darwin_x86_64.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775371
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Darwin_x86_64.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:00Z"
-        digest: sha256:60d42a323918a9f3b17ce562f278974bd97a5a5b311a0145a60a2b2c78e867ba
-        download_count: 0
-        id: 373445251
+        created_at: "2026-04-15T05:52:08Z"
+        digest: sha256:7682c54243d2c16579589f55aac47c51389d26f103f828902880288ba7f0605e
+        download_count: 700
+        id: 396775370
         label: ""
-        name: conftest_0.67.0_Darwin_x86_64.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKD
-        size: 21979364
+        name: conftest_0.68.2_Darwin_x86_64.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_K
+        size: 22058581
         state: uploaded
-        updated_at: "2026-03-13T23:41:02Z"
+        updated_at: "2026-04-15T05:52:09Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -144,19 +145,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445251
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_amd64.deb
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775370
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.deb
         content_type: application/vnd.debian.binary-package
-        created_at: "2026-03-13T23:41:04Z"
-        digest: sha256:8e04eab7fcc5e4ae7b24fedf7e62e298b119db68f9e91a356be5525922fd4592
-        download_count: 0
-        id: 373445316
+        created_at: "2026-04-15T05:52:11Z"
+        digest: sha256:e08650508022f73c414bc5750bd247e3b3f922cc412345faec70c869b1b2d60e
+        download_count: 160
+        id: 396775414
         label: ""
-        name: conftest_0.67.0_linux_amd64.deb
-        node_id: RA_kwDOCp_e9c4WQlLE
-        size: 21480298
+        name: conftest_0.68.2_Linux_arm64.deb
+        node_id: RA_kwDOCp_e9c4Xpk_2
+        size: 19425190
         state: uploaded
-        updated_at: "2026-03-13T23:41:05Z"
+        updated_at: "2026-04-15T05:52:13Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -177,19 +178,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445316
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_amd64.rpm
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775414
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.rpm
         content_type: application/x-rpm
-        created_at: "2026-03-13T23:41:03Z"
-        digest: sha256:39911c9523ee1a3d265f04bb898cc4fea04b4151d0872d8f77ce2461961d351c
-        download_count: 0
-        id: 373445292
+        created_at: "2026-04-15T05:52:13Z"
+        digest: sha256:be183450aaa6a8c79b659a5196549ab77bba42be6553009e70a8855dbbf9bb3c
+        download_count: 129
+        id: 396775442
         label: ""
-        name: conftest_0.67.0_linux_amd64.rpm
-        node_id: RA_kwDOCp_e9c4WQlKs
-        size: 22334046
+        name: conftest_0.68.2_Linux_arm64.rpm
+        node_id: RA_kwDOCp_e9c4XplAS
+        size: 19363243
         state: uploaded
-        updated_at: "2026-03-13T23:41:04Z"
+        updated_at: "2026-04-15T05:52:14Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -210,19 +211,52 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445292
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_arm64.deb
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775442
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.tar.gz
+        content_type: application/gzip
+        created_at: "2026-04-15T05:52:10Z"
+        digest: sha256:4005441089655ded475384cb87d57762ae08ebef78305bada49c70530d2f4184
+        download_count: 33150
+        id: 396775404
+        label: ""
+        name: conftest_0.68.2_Linux_arm64.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_s
+        size: 19424815
+        state: uploaded
+        updated_at: "2026-04-15T05:52:11Z"
+        uploader:
+          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+          gravatar_id: ""
+          html_url: https://github.com/apps/github-actions
+          id: 41898282
+          login: github-actions[bot]
+          node_id: MDM6Qm90NDE4OTgyODI=
+          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+          site_admin: false
+          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+          type: Bot
+          url: https://api.github.com/users/github-actions%5Bbot%5D
+          user_view_type: public
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775404
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.deb
         content_type: application/vnd.debian.binary-package
-        created_at: "2026-03-13T23:41:03Z"
-        digest: sha256:b4e5ddb677e33d403b7eb74f3d974bbcfcbeff50309c4f7f9b08b4b99ec1e05f
-        download_count: 0
-        id: 373445290
+        created_at: "2026-04-15T05:52:11Z"
+        digest: sha256:46b988cc4ae69291559f9de1aa06b115c5e6c3389656febbe880d8a0d9cb978b
+        download_count: 123
+        id: 396775413
         label: ""
-        name: conftest_0.67.0_linux_arm64.deb
-        node_id: RA_kwDOCp_e9c4WQlKq
-        size: 19443702
+        name: conftest_0.68.2_Linux_ppc64le.deb
+        node_id: RA_kwDOCp_e9c4Xpk_1
+        size: 19348466
         state: uploaded
-        updated_at: "2026-03-13T23:41:04Z"
+        updated_at: "2026-04-15T05:52:12Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -243,19 +277,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445290
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_arm64.rpm
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775413
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.rpm
         content_type: application/x-rpm
-        created_at: "2026-03-13T23:41:03Z"
-        digest: sha256:f6893a25a2b277fdecf39a333854af92d20c1f34fdb19830f71b701958df3752
-        download_count: 0
-        id: 373445295
+        created_at: "2026-04-15T05:52:13Z"
+        digest: sha256:021d26bc4946486666efa06499ba78fcf792051170c7fe3456e526b46134c2f1
+        download_count: 123
+        id: 396775445
         label: ""
-        name: conftest_0.67.0_linux_arm64.rpm
-        node_id: RA_kwDOCp_e9c4WQlKv
-        size: 20130871
+        name: conftest_0.68.2_Linux_ppc64le.rpm
+        node_id: RA_kwDOCp_e9c4XplAV
+        size: 19272302
         state: uploaded
-        updated_at: "2026-03-13T23:41:04Z"
+        updated_at: "2026-04-15T05:52:15Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -276,19 +310,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445295
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Linux_arm64.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775445
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:02Z"
-        digest: sha256:bdfd05e17ef899689d02bdf8b9dc1744d3da8053a952c5d67abd8a503881a54a
-        download_count: 0
-        id: 373445268
+        created_at: "2026-04-15T05:52:08Z"
+        digest: sha256:2814b9560329152d1881f3eada73c15b8becf04cdae24367dd057f3d45da1c15
+        download_count: 125
+        id: 396775373
         label: ""
-        name: conftest_0.67.0_Linux_arm64.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKU
-        size: 19353404
+        name: conftest_0.68.2_Linux_ppc64le.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_N
+        size: 19349011
         state: uploaded
-        updated_at: "2026-03-13T23:41:03Z"
+        updated_at: "2026-04-15T05:52:09Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -309,19 +343,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445268
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_ppc64le.deb
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775373
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.deb
         content_type: application/vnd.debian.binary-package
-        created_at: "2026-03-13T23:41:03Z"
-        digest: sha256:55286b502a137e4a57d1be362a3f197e2033e65a591fa37158bf08ea6fd014cf
-        download_count: 0
-        id: 373445291
+        created_at: "2026-04-15T05:52:12Z"
+        digest: sha256:b8df5aeffe300b114c7fc91ccc3f05b03ea618805dd67f1e2e6bfea4cb0f4f82
+        download_count: 10
+        id: 396775419
         label: ""
-        name: conftest_0.67.0_linux_ppc64le.deb
-        node_id: RA_kwDOCp_e9c4WQlKr
-        size: 19380496
+        name: conftest_0.68.2_Linux_s390x.deb
+        node_id: RA_kwDOCp_e9c4Xpk_7
+        size: 20718922
         state: uploaded
-        updated_at: "2026-03-13T23:41:04Z"
+        updated_at: "2026-04-15T05:52:13Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -342,19 +376,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445291
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_ppc64le.rpm
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775419
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.rpm
         content_type: application/x-rpm
-        created_at: "2026-03-13T23:41:04Z"
-        digest: sha256:0d5a53b84f13acaf6dee9f1d5c9ab9bb8d373fc1b908733efaa235ae583300b7
-        download_count: 0
-        id: 373445359
+        created_at: "2026-04-15T05:52:12Z"
+        digest: sha256:af6055c52f5e3516c5e370d56ac7bea66fa1ab5ce26ba0a5b9c160144b692a87
+        download_count: 7
+        id: 396775434
         label: ""
-        name: conftest_0.67.0_linux_ppc64le.rpm
-        node_id: RA_kwDOCp_e9c4WQlLv
-        size: 20093522
+        name: conftest_0.68.2_Linux_s390x.rpm
+        node_id: RA_kwDOCp_e9c4XplAK
+        size: 20694819
         state: uploaded
-        updated_at: "2026-03-13T23:41:05Z"
+        updated_at: "2026-04-15T05:52:14Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -375,19 +409,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445359
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Linux_ppc64le.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775434
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:00Z"
-        digest: sha256:32a53f29afc7d5d4ccb88f3660026bbc26140c716e577407aed853fe7efafbb8
-        download_count: 0
-        id: 373445250
+        created_at: "2026-04-15T05:52:10Z"
+        digest: sha256:5f2651a3097bbaea18df5917753e553efb29738320389cd09bdf87f1a5d67cf9
+        download_count: 10
+        id: 396775408
         label: ""
-        name: conftest_0.67.0_Linux_ppc64le.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKC
-        size: 19275856
+        name: conftest_0.68.2_Linux_s390x.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_w
+        size: 20718607
         state: uploaded
-        updated_at: "2026-03-13T23:41:01Z"
+        updated_at: "2026-04-15T05:52:11Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -408,19 +442,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445250
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_s390x.deb
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775408
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.deb
         content_type: application/vnd.debian.binary-package
-        created_at: "2026-03-13T23:41:04Z"
-        digest: sha256:9cbd9aac422820e7535a808c574e8770f4467a25f3182b1a98922ec54d2d67dc
-        download_count: 0
-        id: 373445345
+        created_at: "2026-04-15T05:52:12Z"
+        digest: sha256:f2a728e2f6834ee4539d69b0eca7958ef8d632efe81639b5558be70383f272a1
+        download_count: 860
+        id: 396775418
         label: ""
-        name: conftest_0.67.0_linux_s390x.deb
-        node_id: RA_kwDOCp_e9c4WQlLh
-        size: 20793616
+        name: conftest_0.68.2_Linux_x86_64.deb
+        node_id: RA_kwDOCp_e9c4Xpk_6
+        size: 21438484
         state: uploaded
-        updated_at: "2026-03-13T23:41:05Z"
+        updated_at: "2026-04-15T05:52:13Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -441,19 +475,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445345
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_linux_s390x.rpm
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775418
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.rpm
         content_type: application/x-rpm
-        created_at: "2026-03-13T23:41:05Z"
-        digest: sha256:5e65b4c3fa48259e2837283e00ec805d8ff06b0b35994ff6db623928cc054568
-        download_count: 0
-        id: 373445363
+        created_at: "2026-04-15T05:52:13Z"
+        digest: sha256:26e9914132080e5bad116de61492acff75d0e9d035acf8bad20376d63dc3dbbc
+        download_count: 32956
+        id: 396775444
         label: ""
-        name: conftest_0.67.0_linux_s390x.rpm
-        node_id: RA_kwDOCp_e9c4WQlLz
-        size: 21876355
+        name: conftest_0.68.2_Linux_x86_64.rpm
+        node_id: RA_kwDOCp_e9c4XplAU
+        size: 21420469
         state: uploaded
-        updated_at: "2026-03-13T23:41:06Z"
+        updated_at: "2026-04-15T05:52:15Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -474,19 +508,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445363
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Linux_s390x.tar.gz
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775444
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.tar.gz
         content_type: application/gzip
-        created_at: "2026-03-13T23:41:02Z"
-        digest: sha256:99037b6ee40e419d5756794ee5828254a5c1653b6f58e426e9d2e8049c207bdf
-        download_count: 0
-        id: 373445272
+        created_at: "2026-04-15T05:52:08Z"
+        digest: sha256:e8144c6d6d2ae0260b869caa60c7c262a1f95ac63ec1e5d2fb19be452d606347
+        download_count: 864378
+        id: 396775369
         label: ""
-        name: conftest_0.67.0_Linux_s390x.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKY
-        size: 20648328
+        name: conftest_0.68.2_Linux_x86_64.tar.gz
+        node_id: RA_kwDOCp_e9c4Xpk_J
+        size: 21443091
         state: uploaded
-        updated_at: "2026-03-13T23:41:03Z"
+        updated_at: "2026-04-15T05:52:09Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -507,52 +541,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445272
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Linux_x86_64.tar.gz
-        content_type: application/gzip
-        created_at: "2026-03-13T23:41:00Z"
-        digest: sha256:a98cfd236f3cadee16d860fbe31cc6edcb0da3efc317f661c7ccd097164b1fdf
-        download_count: 58
-        id: 373445253
-        label: ""
-        name: conftest_0.67.0_Linux_x86_64.tar.gz
-        node_id: RA_kwDOCp_e9c4WQlKF
-        size: 21371288
-        state: uploaded
-        updated_at: "2026-03-13T23:41:01Z"
-        uploader:
-          avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
-          events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
-          followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
-          following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
-          gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
-          gravatar_id: ""
-          html_url: https://github.com/apps/github-actions
-          id: 41898282
-          login: github-actions[bot]
-          node_id: MDM6Qm90NDE4OTgyODI=
-          organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
-          received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
-          repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
-          site_admin: false
-          starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
-          subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
-          type: Bot
-          url: https://api.github.com/users/github-actions%5Bbot%5D
-          user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445253
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Windows_arm64.zip
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775369
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Windows_arm64.zip
         content_type: application/zip
-        created_at: "2026-03-13T23:41:02Z"
-        digest: sha256:2990aa98320f9b2700b8dc5cbd20f368d95e131916a48f1721bc976c97704900
-        download_count: 0
-        id: 373445269
+        created_at: "2026-04-15T05:52:10Z"
+        digest: sha256:d727e11a9b6fe05ae87c0261aeee7e59ca8be718d80cb7bf6c57206d1523823d
+        download_count: 153
+        id: 396775402
         label: ""
-        name: conftest_0.67.0_Windows_arm64.zip
-        node_id: RA_kwDOCp_e9c4WQlKV
-        size: 19515947
+        name: conftest_0.68.2_Windows_arm64.zip
+        node_id: RA_kwDOCp_e9c4Xpk_q
+        size: 19587060
         state: uploaded
-        updated_at: "2026-03-13T23:41:03Z"
+        updated_at: "2026-04-15T05:52:11Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -573,19 +574,19 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445269
-      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.67.0/conftest_0.67.0_Windows_x86_64.zip
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775402
+      - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Windows_x86_64.zip
         content_type: application/zip
-        created_at: "2026-03-13T23:41:02Z"
-        digest: sha256:5ef4018189e4bd789cded334586732584ca2936bb51791d64dc9317672363826
-        download_count: 0
-        id: 373445271
+        created_at: "2026-04-15T05:52:10Z"
+        digest: sha256:66a88d02e6c03a714e9f0751c3d86ee9c5591739c367ca1b79c4f9f2f90ac4cb
+        download_count: 5471
+        id: 396775403
         label: ""
-        name: conftest_0.67.0_Windows_x86_64.zip
-        node_id: RA_kwDOCp_e9c4WQlKX
-        size: 21907428
+        name: conftest_0.68.2_Windows_x86_64.zip
+        node_id: RA_kwDOCp_e9c4Xpk_r
+        size: 21987095
         state: uploaded
-        updated_at: "2026-03-13T23:41:03Z"
+        updated_at: "2026-04-15T05:52:11Z"
         uploader:
           avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
           events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -606,8 +607,8 @@ dependencies:
           type: Bot
           url: https://api.github.com/users/github-actions%5Bbot%5D
           user_view_type: public
-        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/373445271
-      assets_url: https://api.github.com/repos/open-policy-agent/conftest/releases/296915527/assets
+        url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775403
+      assets_url: https://api.github.com/repos/open-policy-agent/conftest/releases/309170097/assets
       author:
         avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
         events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
@@ -630,50 +631,28 @@ dependencies:
         user_view_type: public
       body: |+
         ## Changelog
-        ### Bug Fixes
-        * 69f41ed9d94c2a0cf6f550bc6849a9853415ded2: fix(plugin): Handle spaces in the plugin command path (#1242) (@jalseth)
         ### OPA Changes
-        * 59cb41900a355f3a58938ebd03314a5eaf1d6b17: build(deps): bump github.com/open-policy-agent/opa from 1.12.1 to 1.13.1 (#1262) (@dependabot[bot])
-        * 507345fcd40d28d1e96674f37f68f7c20ae54fec: build(deps): bump github.com/open-policy-agent/opa from 1.13.1 to 1.13.2 (#1274) (@dependabot[bot])
-        * 69b732911dc60db95e8c90c3c1034103667d9afd: build(deps): bump github.com/open-policy-agent/opa from 1.13.2 to 1.14.1 (#1282) (@dependabot[bot])
+        * 36f23bf930b808c73c4e41c6a4eeac5b620b2225: build(deps): bump github.com/open-policy-agent/opa from 1.15.1 to 1.15.2 (#1311) (@dependabot[bot])
         ### Other Changes
-        * 8ec8ba0b69ec78bc4a9d4414e390470a366aae4b: build(deps): bump actions/checkout from 5.0.0 to 6.0.1 (#1230) (@dependabot[bot])
-        * fb1d20ef7543094c4fd3141bc2db9d6d57b6c78b: build(deps): bump alpine from 3.23.2 to 3.23.3 (#1264) (@dependabot[bot])
-        * 84ee4f1d9f0c83accff72364425ec0c1499ff86c: build(deps): bump bats-core/bats-action from 3.0.1 to 4.0.0 (#1270) (@dependabot[bot])
-        * 06f26a62ea85827b8514f8ecb8f59e4833eec00b: build(deps): bump cuelang.org/go from 0.15.1 to 0.15.3 (#1244) (@dependabot[bot])
-        * d01f783589a2933cca99ea2f740096b0767cfa73: build(deps): bump cuelang.org/go from 0.15.3 to 0.15.4 (#1259) (@dependabot[bot])
-        * b7f9627bacbd002d27125731eb9d75a4ca61a9a6: build(deps): bump cuelang.org/go from 0.15.4 to 0.16.0 (#1279) (@dependabot[bot])
-        * 3e4cf9803baf87b3ad0c6e450c01ad4b38c64cc5: build(deps): bump docker/build-push-action from 6.18.0 to 6.19.2 (#1273) (@dependabot[bot])
-        * b7060d3a09365665856f1152015fecad62a6db0b: build(deps): bump github.com/CycloneDX/cyclonedx-go from 0.9.3 to 0.10.0 (#1265) (@dependabot[bot])
-        * e1305130503c0bf1accea6637a006723d422d8dc: build(deps): bump github.com/hashicorp/go-getter from 1.8.3 to 1.8.4 (#1245) (@dependabot[bot])
-        * e5afd3f7e0473a1dab2723159e1bee8ee93bf125: build(deps): bump github.com/hashicorp/go-getter from 1.8.4 to 1.8.5 (#1285) (@dependabot[bot])
-        * d6f5fb22eee63b2938fe96ad30b91802ddaabbea: build(deps): bump github.com/moby/buildkit from 0.26.3 to 0.27.1 (#1260) (@dependabot[bot])
-        * c1ba80692d46b0c03894b97f61648679c98baad1: build(deps): bump github.com/moby/buildkit from 0.27.1 to 0.28.0 (#1280) (@dependabot[bot])
-        * fc5799680f4c2f4b205f4c60d5475b766e440096: build(deps): bump github.com/spdx/tools-golang from 0.5.5 to 0.5.6 (#1243) (@dependabot[bot])
-        * 95d756f10bde86670351a908f39fdc0f940211c2: build(deps): bump github.com/spdx/tools-golang from 0.5.6 to 0.5.7 (#1251) (@dependabot[bot])
-        * a59b8bdefe3f27d45cc3495ee39983849ccd4bc6: build(deps): bump golang from 1.25.5-alpine to 1.25.6-alpine (#1256) (@dependabot[bot])
-        * bde1457c82e9774f1abd23e35f2e4ac1566d7cbe: build(deps): bump golang from 1.25.6-alpine to 1.26.1-alpine (#1281) (@dependabot[bot])
-        * b2e58f0af6e4ec1738aeb282bc8aa1a5b2e44a94: build(deps): bump golangci/golangci-lint-action from 8.0.0 to 9.2.0 (#1231) (@dependabot[bot])
-        * b1e9f30f47c39c793b6950f3fff065675e939ec7: ci: Update Dependabot config (#1267) (@jalseth)
-        * bf63002f44b5ae9b1caf4c48726bf7cd36efbd1c: ci: Update setup-go to use Go version from go.mod (#1268) (@jalseth)
+        * 479de13f22cbf3b776839591c1f46278d81d2573: build(deps): bump github.com/hashicorp/go-getter from 1.8.5 to 1.8.6 (#1307) (@dependabot[bot])
 
-      created_at: "2026-03-13T22:47:55Z"
+      created_at: "2026-04-15T05:14:00Z"
       draft: false
-      html_url: https://github.com/open-policy-agent/conftest/releases/tag/v0.67.0
-      id: 296915527
+      html_url: https://github.com/open-policy-agent/conftest/releases/tag/v0.68.2
+      id: 309170097
       immutable: false
-      mentions_count: 2
-      name: v0.67.0
-      node_id: RE_kwDOCp_e9c4RspJH
+      mentions_count: 1
+      name: v0.68.2
+      node_id: RE_kwDOCp_e9c4SbY-x
       prerelease: false
-      published_at: "2026-03-13T23:41:06Z"
-      tag_name: v0.67.0
-      tarball_url: https://api.github.com/repos/open-policy-agent/conftest/tarball/v0.67.0
+      published_at: "2026-04-15T05:52:15Z"
+      tag_name: v0.68.2
+      tarball_url: https://api.github.com/repos/open-policy-agent/conftest/tarball/v0.68.2
       target_commitish: master
-      updated_at: "2026-03-13T23:41:06Z"
-      upload_url: https://uploads.github.com/repos/open-policy-agent/conftest/releases/296915527/assets{?name,label}
-      url: https://api.github.com/repos/open-policy-agent/conftest/releases/296915527
-      zipball_url: https://api.github.com/repos/open-policy-agent/conftest/zipball/v0.67.0
+      updated_at: "2026-04-15T05:52:15Z"
+      upload_url: https://uploads.github.com/repos/open-policy-agent/conftest/releases/309170097/assets{?name,label}
+      url: https://api.github.com/repos/open-policy-agent/conftest/releases/309170097
+      zipball_url: https://api.github.com/repos/open-policy-agent/conftest/zipball/v0.68.2
 meta:
   dependencies:
     conftest:
@@ -22586,3 +22565,612 @@ meta:
           upload_url: https://uploads.github.com/repos/open-policy-agent/conftest/releases/296915527/assets{?name,label}
           url: https://api.github.com/repos/open-policy-agent/conftest/releases/296915527
           zipball_url: https://api.github.com/repos/open-policy-agent/conftest/zipball/v0.67.0
+      0.68.2:
+        githubRelease:
+          assets:
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/checksums.txt
+            content_type: text/plain; charset=utf-8
+            created_at: "2026-04-15T05:52:14Z"
+            digest: sha256:08026fd5858d1c08556b50d5a43a8deb03d00b617d46f073a5528910ac0a3e46
+            download_count: 85635
+            id: 396775451
+            label: ""
+            name: checksums.txt
+            node_id: RA_kwDOCp_e9c4XplAb
+            size: 1603
+            state: uploaded
+            updated_at: "2026-04-15T05:52:14Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775451
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Darwin_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:08Z"
+            digest: sha256:cdb5445179e0cc42906e2b0233694900f272a501878d416a9c875b1f7bdfd34c
+            download_count: 3144
+            id: 396775371
+            label: ""
+            name: conftest_0.68.2_Darwin_arm64.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_L
+            size: 20564654
+            state: uploaded
+            updated_at: "2026-04-15T05:52:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775371
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Darwin_x86_64.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:08Z"
+            digest: sha256:7682c54243d2c16579589f55aac47c51389d26f103f828902880288ba7f0605e
+            download_count: 700
+            id: 396775370
+            label: ""
+            name: conftest_0.68.2_Darwin_x86_64.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_K
+            size: 22058581
+            state: uploaded
+            updated_at: "2026-04-15T05:52:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775370
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.deb
+            content_type: application/vnd.debian.binary-package
+            created_at: "2026-04-15T05:52:11Z"
+            digest: sha256:e08650508022f73c414bc5750bd247e3b3f922cc412345faec70c869b1b2d60e
+            download_count: 160
+            id: 396775414
+            label: ""
+            name: conftest_0.68.2_Linux_arm64.deb
+            node_id: RA_kwDOCp_e9c4Xpk_2
+            size: 19425190
+            state: uploaded
+            updated_at: "2026-04-15T05:52:13Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775414
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.rpm
+            content_type: application/x-rpm
+            created_at: "2026-04-15T05:52:13Z"
+            digest: sha256:be183450aaa6a8c79b659a5196549ab77bba42be6553009e70a8855dbbf9bb3c
+            download_count: 129
+            id: 396775442
+            label: ""
+            name: conftest_0.68.2_Linux_arm64.rpm
+            node_id: RA_kwDOCp_e9c4XplAS
+            size: 19363243
+            state: uploaded
+            updated_at: "2026-04-15T05:52:14Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775442
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_arm64.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:10Z"
+            digest: sha256:4005441089655ded475384cb87d57762ae08ebef78305bada49c70530d2f4184
+            download_count: 33150
+            id: 396775404
+            label: ""
+            name: conftest_0.68.2_Linux_arm64.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_s
+            size: 19424815
+            state: uploaded
+            updated_at: "2026-04-15T05:52:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775404
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.deb
+            content_type: application/vnd.debian.binary-package
+            created_at: "2026-04-15T05:52:11Z"
+            digest: sha256:46b988cc4ae69291559f9de1aa06b115c5e6c3389656febbe880d8a0d9cb978b
+            download_count: 123
+            id: 396775413
+            label: ""
+            name: conftest_0.68.2_Linux_ppc64le.deb
+            node_id: RA_kwDOCp_e9c4Xpk_1
+            size: 19348466
+            state: uploaded
+            updated_at: "2026-04-15T05:52:12Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775413
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.rpm
+            content_type: application/x-rpm
+            created_at: "2026-04-15T05:52:13Z"
+            digest: sha256:021d26bc4946486666efa06499ba78fcf792051170c7fe3456e526b46134c2f1
+            download_count: 123
+            id: 396775445
+            label: ""
+            name: conftest_0.68.2_Linux_ppc64le.rpm
+            node_id: RA_kwDOCp_e9c4XplAV
+            size: 19272302
+            state: uploaded
+            updated_at: "2026-04-15T05:52:15Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775445
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_ppc64le.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:08Z"
+            digest: sha256:2814b9560329152d1881f3eada73c15b8becf04cdae24367dd057f3d45da1c15
+            download_count: 125
+            id: 396775373
+            label: ""
+            name: conftest_0.68.2_Linux_ppc64le.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_N
+            size: 19349011
+            state: uploaded
+            updated_at: "2026-04-15T05:52:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775373
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.deb
+            content_type: application/vnd.debian.binary-package
+            created_at: "2026-04-15T05:52:12Z"
+            digest: sha256:b8df5aeffe300b114c7fc91ccc3f05b03ea618805dd67f1e2e6bfea4cb0f4f82
+            download_count: 10
+            id: 396775419
+            label: ""
+            name: conftest_0.68.2_Linux_s390x.deb
+            node_id: RA_kwDOCp_e9c4Xpk_7
+            size: 20718922
+            state: uploaded
+            updated_at: "2026-04-15T05:52:13Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775419
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.rpm
+            content_type: application/x-rpm
+            created_at: "2026-04-15T05:52:12Z"
+            digest: sha256:af6055c52f5e3516c5e370d56ac7bea66fa1ab5ce26ba0a5b9c160144b692a87
+            download_count: 7
+            id: 396775434
+            label: ""
+            name: conftest_0.68.2_Linux_s390x.rpm
+            node_id: RA_kwDOCp_e9c4XplAK
+            size: 20694819
+            state: uploaded
+            updated_at: "2026-04-15T05:52:14Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775434
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_s390x.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:10Z"
+            digest: sha256:5f2651a3097bbaea18df5917753e553efb29738320389cd09bdf87f1a5d67cf9
+            download_count: 10
+            id: 396775408
+            label: ""
+            name: conftest_0.68.2_Linux_s390x.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_w
+            size: 20718607
+            state: uploaded
+            updated_at: "2026-04-15T05:52:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775408
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.deb
+            content_type: application/vnd.debian.binary-package
+            created_at: "2026-04-15T05:52:12Z"
+            digest: sha256:f2a728e2f6834ee4539d69b0eca7958ef8d632efe81639b5558be70383f272a1
+            download_count: 860
+            id: 396775418
+            label: ""
+            name: conftest_0.68.2_Linux_x86_64.deb
+            node_id: RA_kwDOCp_e9c4Xpk_6
+            size: 21438484
+            state: uploaded
+            updated_at: "2026-04-15T05:52:13Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775418
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.rpm
+            content_type: application/x-rpm
+            created_at: "2026-04-15T05:52:13Z"
+            digest: sha256:26e9914132080e5bad116de61492acff75d0e9d035acf8bad20376d63dc3dbbc
+            download_count: 32956
+            id: 396775444
+            label: ""
+            name: conftest_0.68.2_Linux_x86_64.rpm
+            node_id: RA_kwDOCp_e9c4XplAU
+            size: 21420469
+            state: uploaded
+            updated_at: "2026-04-15T05:52:15Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775444
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Linux_x86_64.tar.gz
+            content_type: application/gzip
+            created_at: "2026-04-15T05:52:08Z"
+            digest: sha256:e8144c6d6d2ae0260b869caa60c7c262a1f95ac63ec1e5d2fb19be452d606347
+            download_count: 864378
+            id: 396775369
+            label: ""
+            name: conftest_0.68.2_Linux_x86_64.tar.gz
+            node_id: RA_kwDOCp_e9c4Xpk_J
+            size: 21443091
+            state: uploaded
+            updated_at: "2026-04-15T05:52:09Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775369
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Windows_arm64.zip
+            content_type: application/zip
+            created_at: "2026-04-15T05:52:10Z"
+            digest: sha256:d727e11a9b6fe05ae87c0261aeee7e59ca8be718d80cb7bf6c57206d1523823d
+            download_count: 153
+            id: 396775402
+            label: ""
+            name: conftest_0.68.2_Windows_arm64.zip
+            node_id: RA_kwDOCp_e9c4Xpk_q
+            size: 19587060
+            state: uploaded
+            updated_at: "2026-04-15T05:52:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775402
+          - browser_download_url: https://github.com/open-policy-agent/conftest/releases/download/v0.68.2/conftest_0.68.2_Windows_x86_64.zip
+            content_type: application/zip
+            created_at: "2026-04-15T05:52:10Z"
+            digest: sha256:66a88d02e6c03a714e9f0751c3d86ee9c5591739c367ca1b79c4f9f2f90ac4cb
+            download_count: 5471
+            id: 396775403
+            label: ""
+            name: conftest_0.68.2_Windows_x86_64.zip
+            node_id: RA_kwDOCp_e9c4Xpk_r
+            size: 21987095
+            state: uploaded
+            updated_at: "2026-04-15T05:52:11Z"
+            uploader:
+              avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+              events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+              followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+              following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+              gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+              gravatar_id: ""
+              html_url: https://github.com/apps/github-actions
+              id: 41898282
+              login: github-actions[bot]
+              node_id: MDM6Qm90NDE4OTgyODI=
+              organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+              received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+              repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+              type: Bot
+              url: https://api.github.com/users/github-actions%5Bbot%5D
+              user_view_type: public
+            url: https://api.github.com/repos/open-policy-agent/conftest/releases/assets/396775403
+          assets_url: https://api.github.com/repos/open-policy-agent/conftest/releases/309170097/assets
+          author:
+            avatar_url: https://avatars.githubusercontent.com/in/15368?v=4
+            events_url: https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}
+            followers_url: https://api.github.com/users/github-actions%5Bbot%5D/followers
+            following_url: https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
+            gists_url: https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}
+            gravatar_id: ""
+            html_url: https://github.com/apps/github-actions
+            id: 41898282
+            login: github-actions[bot]
+            node_id: MDM6Qm90NDE4OTgyODI=
+            organizations_url: https://api.github.com/users/github-actions%5Bbot%5D/orgs
+            received_events_url: https://api.github.com/users/github-actions%5Bbot%5D/received_events
+            repos_url: https://api.github.com/users/github-actions%5Bbot%5D/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/github-actions%5Bbot%5D/subscriptions
+            type: Bot
+            url: https://api.github.com/users/github-actions%5Bbot%5D
+            user_view_type: public
+          body: |+
+            ## Changelog
+            ### OPA Changes
+            * 36f23bf930b808c73c4e41c6a4eeac5b620b2225: build(deps): bump github.com/open-policy-agent/opa from 1.15.1 to 1.15.2 (#1311) (@dependabot[bot])
+            ### Other Changes
+            * 479de13f22cbf3b776839591c1f46278d81d2573: build(deps): bump github.com/hashicorp/go-getter from 1.8.5 to 1.8.6 (#1307) (@dependabot[bot])
+
+          created_at: "2026-04-15T05:14:00Z"
+          draft: false
+          html_url: https://github.com/open-policy-agent/conftest/releases/tag/v0.68.2
+          id: 309170097
+          immutable: false
+          mentions_count: 1
+          name: v0.68.2
+          node_id: RE_kwDOCp_e9c4SbY-x
+          prerelease: false
+          published_at: "2026-04-15T05:52:15Z"
+          tag_name: v0.68.2
+          tarball_url: https://api.github.com/repos/open-policy-agent/conftest/tarball/v0.68.2
+          target_commitish: master
+          updated_at: "2026-04-15T05:52:15Z"
+          upload_url: https://uploads.github.com/repos/open-policy-agent/conftest/releases/309170097/assets{?name,label}
+          url: https://api.github.com/repos/open-policy-agent/conftest/releases/309170097
+          zipball_url: https://api.github.com/repos/open-policy-agent/conftest/zipball/v0.68.2


### PR DESCRIPTION
## Summary
- Since conftest v0.67.1, the release asset filenames changed from `conftest_{version}_linux_amd64.{deb,rpm}` to `conftest_{version}_Linux_x86_64.{deb,rpm}`, which broke every automated version-bump PR since then (#4183, #4184, #4297, #4299)
- Fixed `atlantis-aws/Dockerfile.tpl` (the `Dockerfile` there is generated from this template via `mod provision`) to resolve the architecture name using the same `case "${TARGETARCH}"` pattern already used for terraform/dumb-init in the same file, and applied the same fix to `conftest/Dockerfile`
- After the logic fix, ran `mod up` → `mod provision` to bump `CONFTEST_VERSION` and regenerate `variant.lock` (no manual version edits). `atlantis-aws/variant.mod` manages multiple dependencies in one template, so the awscli base image, Atlantis, and Terraform versions were also bumped as a side effect

## Related
- SREP-4481
- Replaces auto-generated PRs #4297 and #4299 (both closed in favor of this PR)

## Test plan
- [x] `make build` / goss tests (atlantis-aws, conftest, local arm64, all passed)
- [x] `docker buildx build --platform linux/amd64` (both directories, cross-build verified, succeeded)
- [x] GitHub Actions Integration workflow: both amd64/arm64 test jobs green